### PR TITLE
[DVC-5168] feat: add location call to proxy server 

### DIFF
--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -4,6 +4,7 @@ import Router from "koa-router";
 import bodyParser from "koa-bodyparser";
 import { handleUser } from "./handlers/user";
 import { handleClient } from "./handlers/client";
+import { handleLocation } from "./handlers/location";
 
 type Data = {
   clients: { [key: string]: DVCClient };
@@ -21,23 +22,26 @@ async function start() {
   const app = new Koa();
   app.use(bodyParser());
 
-    const router = new Router()
+  const router = new Router();
 
-    router.get('/spec', (ctx) => {
-        ctx.status = 200
-        ctx.body = {
-            name: 'NodeJS',
-            version: '', // TODO add branch name or sdk version here
-            capabilities: ['EdgeDB', 'LocalBucketing'],
-        }
-    })
+  router.get("/spec", (ctx) => {
+    ctx.status = 200;
+    ctx.body = {
+      name: "NodeJS",
+      version: "", // TODO add branch name or sdk version here
+      capabilities: ["EdgeDB", "LocalBucketing"],
+    };
+  });
 
-    router.post('/client', (ctx: Koa.ParameterizedContext) => {
-        handleClient(ctx, data.clients)
-    })
-    router.post('/user', (ctx: Koa.ParameterizedContext) => {
-        handleUser(ctx, data.users)
-    })
+  router.post("/client", (ctx: Koa.ParameterizedContext) => {
+    handleClient(ctx, data.clients);
+  });
+  router.post("/user", (ctx: Koa.ParameterizedContext) => {
+    handleUser(ctx, data.users);
+  });
+  router.post("/:location*", (ctx: Koa.ParameterizedContext) => {
+    handleLocation(ctx, data);
+  });
 
   app.use(router.routes()).use(router.allowedMethods());
 

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -1,25 +1,25 @@
-import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
-import Koa from 'koa'
-import Router from 'koa-router'
-import bodyParser from 'koa-bodyparser'
-import { handleUser } from './handlers/user'
-import { handleClient } from './handlers/client'
+import { DVCClient, DVCUser } from "@devcycle/nodejs-server-sdk";
+import Koa from "koa";
+import Router from "koa-router";
+import bodyParser from "koa-bodyparser";
+import { handleUser } from "./handlers/user";
+import { handleClient } from "./handlers/client";
 
 type Data = {
-  clients: { [key: string]: DVCClient }
-  users: { [key: string]: DVCUser }
-  commandResults: { [key: string]: any }
-}
+  clients: { [key: string]: DVCClient };
+  users: { [key: string]: DVCUser };
+  commandResults: { [key: string]: any };
+};
 
 const data: Data = {
-    clients: {},
-    users: {},
-    commandResults: {}
-}
+  clients: {},
+  users: {},
+  commandResults: {},
+};
 
 async function start() {
-    const app = new Koa()
-    app.use(bodyParser())
+  const app = new Koa();
+  app.use(bodyParser());
 
     const router = new Router()
 
@@ -39,11 +39,11 @@ async function start() {
         handleUser(ctx, data.users)
     })
 
-    app.use(router.routes()).use(router.allowedMethods())
+  app.use(router.routes()).use(router.allowedMethods());
 
-    // Server!
-    console.log('Server started on port 3000')
-    app.listen(3000)
+  // Server!
+  console.log("Server started on port 3000");
+  app.listen(3000);
 }
 
-start()
+start();

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -1,16 +1,11 @@
-import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
 import Koa from 'koa'
 import Router from 'koa-router'
 import bodyParser from 'koa-bodyparser'
 import { handleUser } from './handlers/user'
 import { handleClient } from './handlers/client'
 import { handleLocation } from './handlers/location'
+import { Data } from './entityTypes'
 
-type Data = {
-  clients: { [key: string]: DVCClient }
-  users: { [key: string]: DVCUser }
-  commandResults: { [key: string]: any }
-}
 
 const data: Data = {
     clients: {},

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -7,10 +7,10 @@ import { handleClient } from './handlers/client'
 import { handleLocation } from './handlers/location'
 
 type Data = {
-  clients: { [key: string]: DVCClient };
-  users: { [key: string]: DVCUser };
-  commandResults: { [key: string]: any };
-};
+  clients: { [key: string]: DVCClient }
+  users: { [key: string]: DVCUser }
+  commandResults: { [key: string]: any }
+}
 
 const data: Data = {
     clients: {},

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -3,9 +3,8 @@ import Router from 'koa-router'
 import bodyParser from 'koa-bodyparser'
 import { handleUser } from './handlers/user'
 import { handleClient } from './handlers/client'
-import { handleLocation } from './handlers/location'
+import { validateLocationRequest } from './handlers/location'
 import { Data } from './entityTypes'
-
 
 const data: Data = {
     clients: {},
@@ -35,7 +34,7 @@ async function start() {
         handleUser(ctx, data.users)
     })
     router.post('/:location*', (ctx: Koa.ParameterizedContext) => {
-        handleLocation(ctx, data)
+        validateLocationRequest(ctx, data)
     })
 
     app.use(router.routes()).use(router.allowedMethods())

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -1,10 +1,10 @@
-import { DVCClient, DVCUser } from "@devcycle/nodejs-server-sdk";
-import Koa from "koa";
-import Router from "koa-router";
-import bodyParser from "koa-bodyparser";
-import { handleUser } from "./handlers/user";
-import { handleClient } from "./handlers/client";
-import { handleLocation } from "./handlers/location";
+import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
+import Koa from 'koa'
+import Router from 'koa-router'
+import bodyParser from 'koa-bodyparser'
+import { handleUser } from './handlers/user'
+import { handleClient } from './handlers/client'
+import { handleLocation } from './handlers/location'
 
 type Data = {
   clients: { [key: string]: DVCClient };
@@ -13,41 +13,41 @@ type Data = {
 };
 
 const data: Data = {
-  clients: {},
-  users: {},
-  commandResults: {},
-};
-
-async function start() {
-  const app = new Koa();
-  app.use(bodyParser());
-
-  const router = new Router();
-
-  router.get("/spec", (ctx) => {
-    ctx.status = 200;
-    ctx.body = {
-      name: "NodeJS",
-      version: "", // TODO add branch name or sdk version here
-      capabilities: ["EdgeDB", "LocalBucketing"],
-    };
-  });
-
-  router.post("/client", (ctx: Koa.ParameterizedContext) => {
-    handleClient(ctx, data.clients);
-  });
-  router.post("/user", (ctx: Koa.ParameterizedContext) => {
-    handleUser(ctx, data.users);
-  });
-  router.post("/:location*", (ctx: Koa.ParameterizedContext) => {
-    handleLocation(ctx, data);
-  });
-
-  app.use(router.routes()).use(router.allowedMethods());
-
-  // Server!
-  console.log("Server started on port 3000");
-  app.listen(3000);
+    clients: {},
+    users: {},
+    commandResults: {},
 }
 
-start();
+async function start() {
+    const app = new Koa()
+    app.use(bodyParser())
+
+    const router = new Router()
+
+    router.get('/spec', (ctx) => {
+        ctx.status = 200
+        ctx.body = {
+            name: 'NodeJS',
+            version: '', // TODO add branch name or sdk version here
+            capabilities: ['EdgeDB', 'LocalBucketing'],
+        }
+    })
+
+    router.post('/client', (ctx: Koa.ParameterizedContext) => {
+        handleClient(ctx, data.clients)
+    })
+    router.post('/user', (ctx: Koa.ParameterizedContext) => {
+        handleUser(ctx, data.users)
+    })
+    router.post('/:location*', (ctx: Koa.ParameterizedContext) => {
+        handleLocation(ctx, data)
+    })
+
+    app.use(router.routes()).use(router.allowedMethods())
+
+    // Server!
+    console.log('Server started on port 3000')
+    app.listen(3000)
+}
+
+start()

--- a/proxies/nodejs/entityTypes.ts
+++ b/proxies/nodejs/entityTypes.ts
@@ -5,7 +5,7 @@ export enum EntityTypes {
   object = 'Object',
 }
 
-export const convertEntityTypes = (value: string): EntityTypes => {
+export const getEntityModelFromType = (value: string): EntityTypes => {
     switch (value) {
         case 'DVCUser':
             return EntityTypes.user
@@ -17,5 +17,20 @@ export const convertEntityTypes = (value: string): EntityTypes => {
             return EntityTypes.object
         default:
             return EntityTypes.object
+    }
+}
+
+export const getEntityNameFromType = (value: string): string => {
+    switch (value) {
+        case 'DVCUser':
+            return 'user'
+        case 'DVCVariable':
+            return 'variable'
+        case 'DVCFeature':
+            return 'feature'
+        case 'DVCObject':
+            return 'object'
+        default:
+            return 'object'
     }
 }

--- a/proxies/nodejs/entityTypes.ts
+++ b/proxies/nodejs/entityTypes.ts
@@ -1,21 +1,21 @@
 export enum EntityTypes {
-  user = "User",
-  variable = "Variable",
-  feature = "Feature",
-  object = "Object",
+  user = 'User',
+  variable = 'Variable',
+  feature = 'Feature',
+  object = 'Object',
 }
 
 export const convertEntityTypes = (value: string): EntityTypes => {
-  switch (value) {
-    case "DVCUser":
-      return EntityTypes.user;
-    case "DVCVariable":
-      return EntityTypes.variable;
-    case "DVCFeature":
-      return EntityTypes.feature;
-    case "DVCObject":
-      return EntityTypes.object;
-    default:
-      return EntityTypes.object;
-  }
-};
+    switch (value) {
+        case 'DVCUser':
+            return EntityTypes.user
+        case 'DVCVariable':
+            return EntityTypes.variable
+        case 'DVCFeature':
+            return EntityTypes.feature
+        case 'DVCObject':
+            return EntityTypes.object
+        default:
+            return EntityTypes.object
+    }
+}

--- a/proxies/nodejs/entityTypes.ts
+++ b/proxies/nodejs/entityTypes.ts
@@ -2,5 +2,20 @@ export enum EntityTypes {
   user = "User",
   variable = "Variable",
   feature = "Feature",
-  object = "Object"
+  object = "Object",
 }
+
+export const convertEntityTypes = (value: string): EntityTypes => {
+  switch (value) {
+    case "DVCUser":
+      return EntityTypes.user;
+    case "DVCVariable":
+      return EntityTypes.variable;
+    case "DVCFeature":
+      return EntityTypes.feature;
+    case "DVCObject":
+      return EntityTypes.object;
+    default:
+      return EntityTypes.object;
+  }
+};

--- a/proxies/nodejs/entityTypes.ts
+++ b/proxies/nodejs/entityTypes.ts
@@ -26,8 +26,6 @@ export const getEntityFromType = (value: string): Entity => {
             return { type: EntityTypes.variable, model: 'variable' }
         case 'DVCFeature':
             return { type: EntityTypes.feature, model: 'feature' }
-        case 'DVCObject':
-            return { type: EntityTypes.object, model: 'object' }
         default:
             return { type: EntityTypes.object, model: 'object' }
     }

--- a/proxies/nodejs/entityTypes.ts
+++ b/proxies/nodejs/entityTypes.ts
@@ -1,36 +1,26 @@
 export enum EntityTypes {
-  user = 'User',
-  variable = 'Variable',
-  feature = 'Feature',
-  object = 'Object',
+    user = 'User',
+    variable = 'Variable',
+    feature = 'Feature',
+    object = 'Object',
 }
 
-export const getEntityModelFromType = (value: string): EntityTypes => {
-    switch (value) {
-        case 'DVCUser':
-            return EntityTypes.user
-        case 'DVCVariable':
-            return EntityTypes.variable
-        case 'DVCFeature':
-            return EntityTypes.feature
-        case 'DVCObject':
-            return EntityTypes.object
-        default:
-            return EntityTypes.object
-    }
+type Entity = {
+    type: EntityTypes,
+    model: string
 }
 
-export const getEntityNameFromType = (value: string): string => {
+export const getEntityFromType = (value: string): Entity => {
     switch (value) {
         case 'DVCUser':
-            return 'user'
+            return { type: EntityTypes.user, model: 'user' }
         case 'DVCVariable':
-            return 'variable'
+            return { type: EntityTypes.variable, model: 'variable' }
         case 'DVCFeature':
-            return 'feature'
+            return { type: EntityTypes.feature, model: 'feature' }
         case 'DVCObject':
-            return 'object'
+            return { type: EntityTypes.object, model: 'object' }
         default:
-            return 'object'
+            return { type: EntityTypes.object, model: 'object' }
     }
 }

--- a/proxies/nodejs/entityTypes.ts
+++ b/proxies/nodejs/entityTypes.ts
@@ -7,26 +7,21 @@ export enum EntityTypes {
     object = 'Object',
 }
 
-type Entity = {
-    type: EntityTypes,
-    model: string
-}
-
 export type Data = {
     clients: { [key: string]: DVCClient }
     users: { [key: string]: DVCUser }
     commandResults: { [key: string]: any }
 }
 
-export const getEntityFromType = (value: string): Entity => {
+export const getEntityFromType = (value: string): string => {
     switch (value) {
         case 'DVCUser':
-            return { type: EntityTypes.user, model: 'user' }
+            return EntityTypes.user
         case 'DVCVariable':
-            return { type: EntityTypes.variable, model: 'variable' }
+            return EntityTypes.variable
         case 'DVCFeature':
-            return { type: EntityTypes.feature, model: 'feature' }
+            return EntityTypes.feature
         default:
-            return { type: EntityTypes.object, model: 'object' }
+            return EntityTypes.object
     }
 }

--- a/proxies/nodejs/entityTypes.ts
+++ b/proxies/nodejs/entityTypes.ts
@@ -1,3 +1,5 @@
+import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
+
 export enum EntityTypes {
     user = 'User',
     variable = 'Variable',
@@ -8,6 +10,12 @@ export enum EntityTypes {
 type Entity = {
     type: EntityTypes,
     model: string
+}
+
+export type Data = {
+    clients: { [key: string]: DVCClient }
+    users: { [key: string]: DVCUser }
+    commandResults: { [key: string]: any }
 }
 
 export const getEntityFromType = (value: string): Entity => {

--- a/proxies/nodejs/handlers/client.ts
+++ b/proxies/nodejs/handlers/client.ts
@@ -8,23 +8,23 @@ type ClientRequestBody = {
 }
 
 export const handleClient = async (ctx: Koa.ParameterizedContext, clients: { [key: string]: DVCClient }) => {
-  const body = <ClientRequestBody>ctx.request.body
-  if (body.clientId === undefined) {
-    ctx.status = 400
-    ctx.body = {
-      error: "Invalid request: missing clientId"
+    const body = <ClientRequestBody>ctx.request.body
+    if (body.clientId === undefined) {
+        ctx.status = 400
+        ctx.body = {
+            error: 'Invalid request: missing clientId'
+        }
+    } else {
+        try {
+            const client = initialize(body.sdkKey, body.options)
+            clients[body.clientId] = client
+            ctx.status = 201
+            ctx.set('Location',`client/${body.clientId}`)
+        } catch (error) {
+            ctx.status = 200
+            ctx.body = {
+                exception: error.message
+            }
+        }
     }
-  } else {
-    try {
-      const client = initialize(body.sdkKey, body.options)
-      clients[body.clientId] = client
-      ctx.status = 201
-      ctx.set('Location',`client/${body.clientId}`)
-    } catch (error) {
-      ctx.status = 200
-      ctx.body = {
-        exception: error.message
-      }
-    }
-  }
 }

--- a/proxies/nodejs/handlers/client.ts
+++ b/proxies/nodejs/handlers/client.ts
@@ -2,9 +2,9 @@ import Koa from 'koa'
 import { DVCClient, initialize } from '@devcycle/nodejs-server-sdk'
 
 type ClientRequestBody = {
-  clientId: string
-  sdkKey: string
-  options: { [key: string]: string }
+    clientId: string
+    sdkKey: string
+    options: { [key: string]: string }
 }
 
 export const handleClient = async (ctx: Koa.ParameterizedContext, clients: { [key: string]: DVCClient }) => {
@@ -14,17 +14,17 @@ export const handleClient = async (ctx: Koa.ParameterizedContext, clients: { [ke
         ctx.body = {
             error: 'Invalid request: missing clientId'
         }
-    } else {
-        try {
-            const client = initialize(body.sdkKey, body.options)
-            clients[body.clientId] = client
-            ctx.status = 201
-            ctx.set('Location',`client/${body.clientId}`)
-        } catch (error) {
-            ctx.status = 200
-            ctx.body = {
-                exception: error.message
-            }
+        return ctx
+    }
+    try {
+        const client = initialize(body.sdkKey, body.options)
+        clients[body.clientId] = client
+        ctx.status = 201
+        ctx.set('Location', `client/${body.clientId}`)
+    } catch (error) {
+        ctx.status = 200
+        ctx.body = {
+            exception: error.message
         }
     }
 }

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -1,0 +1,111 @@
+import Koa from "koa";
+import { DVCClient, DVCUser } from "@devcycle/nodejs-server-sdk";
+import { convertEntityTypes } from "../entityTypes";
+
+type LocationRequestBody = {
+  command: string;
+  params: string; //[{value: string | number | boolean} | {location: string} | {callbackUrl: string}] HTTP request comes in as string
+  isAsync: boolean;
+};
+
+export const handleLocation = async (
+  ctx: Koa.ParameterizedContext,
+  data: {
+    clients: { [key: string]: DVCClient };
+    users: { [key: string]: DVCUser };
+  }
+) => {
+  const body = ctx.request.body as LocationRequestBody;
+  const urlParts = ctx.request.url.split("/");
+  console.log(urlParts);
+  let entity = getEntityFromLocation(ctx.request.url, data);
+  console.log("entity", entity);
+
+  if (entity === undefined) {
+    ctx.status = 400;
+    ctx.body = {
+      errorCode: 400,
+      errorMessage: "Invalid request: missing entity",
+    };
+  } else if (body.command === undefined) {
+    ctx.status = 400;
+    ctx.body = {
+      errorCode: 400,
+      errorMessage: "Invalid request: missing command",
+    };
+  } else {
+    try {
+      const command = body.command;
+      const params: any | string | boolean | number = parseParams(
+        JSON.parse(body.params),
+        data
+      );
+
+      // TODO: handle async commands
+      // TODO: handle callback before invoking command
+      const resultData = await invokeCommand(
+        entity,
+        command,
+        params,
+        body.isAsync
+      );
+
+      ctx.status = 200;
+      ctx.body = {
+        entityType: convertEntityTypes(resultData.constructor.name), // assuming this is the type of the entity for returned data
+        data: resultData,
+        logs: [], // TODO add logs here
+      };
+    } catch (error) {
+      if (body.isAsync) {
+        ctx.status = 200;
+        ctx.body = {
+          asyncError: error.message,
+          errorCode: error.code,
+        };
+      } else {
+        ctx.status = 200;
+        ctx.body = {
+          errorCode: error.code,
+          exception: error.message,
+        };
+      }
+    }
+  }
+};
+
+const getEntityFromLocation = (location, data) => {
+  const urlParts = location.split("/");
+  const entityType = urlParts[urlParts.length - 2];
+  const id = urlParts[urlParts.length - 1];
+  let entity;
+  if (entityType === "user") {
+    entity = data.users[id];
+  }
+  if (entityType === "client") {
+    entity = data.clients[id];
+  }
+  return entity;
+};
+
+const parseParams = (params, data): (string | boolean | number | any)[] => {
+  const parsedParams: (string | boolean | number | any)[] = [];
+  params.forEach((element) => {
+    if (element.value !== undefined) {
+      parsedParams.push(element.value);
+    } else if (element.location !== undefined) {
+      parsedParams.push(getEntityFromLocation(element.location, data));
+    }
+  });
+  return parsedParams;
+};
+
+const invokeCommand = async (entity, command, params, isAsync) => {
+  if (isAsync) {
+    const result = await entity[command](...params);
+    return result;
+  }
+  {
+    return entity[command](...params);
+  }
+};

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -10,11 +10,10 @@ type LocationRequestBody = {
 
 export const handleLocation = async (
     ctx: Koa.ParameterizedContext,
-    data: Data
+    data: Data,
+    body: LocationRequestBody,
+    entity: any
 ) => {
-    const entity = getEntityFromLocation(ctx.request.url, data)
-    const body = ctx.request.body as LocationRequestBody
-    validateRequest(ctx, data, body, entity)
 
     try {
         const command = body.command
@@ -51,6 +50,7 @@ export const handleLocation = async (
             logs: [], // TODO add logs here
         }
         console.log('dataObject: ', data)
+        console.log('logger: ', entity.logger.info)
 
     } catch (error) {
         console.error(error)
@@ -121,21 +121,26 @@ const invokeCommand = async (entity, command, params, isAsync) => {
 
 }
 
-const validateRequest = (ctx: Koa.ParameterizedContext, data: Data, body: LocationRequestBody, entity: any) => {
-    if (entity === undefined) {
-        ctx.status = 400
-        ctx.body = {
-            errorCode: 400,
-            errorMessage: 'Invalid request: missing entity',
+export const validateLocationRequest =
+    (ctx: Koa.ParameterizedContext, data: Data) => {
+        const entity = getEntityFromLocation(ctx.request.url, data)
+        const body = ctx.request.body as LocationRequestBody
+
+        if (entity === undefined) {
+            ctx.status = 400
+            ctx.body = {
+                errorCode: 400,
+                errorMessage: 'Invalid request: missing entity',
+            }
+            return ctx
         }
-        return ctx
-    }
-    if (body.command === undefined) {
-        ctx.status = 400
-        ctx.body = {
-            errorCode: 400,
-            errorMessage: 'Invalid request: missing command',
+        if (body.command === undefined) {
+            ctx.status = 400
+            ctx.body = {
+                errorCode: 400,
+                errorMessage: 'Invalid request: missing command',
+            }
+            return ctx
         }
-        return ctx
+        handleLocation(ctx, data, body, entity)
     }
-}

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -1,111 +1,112 @@
-import Koa from "koa";
-import { DVCClient, DVCUser } from "@devcycle/nodejs-server-sdk";
-import { convertEntityTypes } from "../entityTypes";
+import Koa from 'koa'
+import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
+import { convertEntityTypes } from '../entityTypes'
 
+//HTTP request comes in as string
 type LocationRequestBody = {
   command: string;
-  params: string; //[{value: string | number | boolean} | {location: string} | {callbackUrl: string}] HTTP request comes in as string
+  params: string; //[{value: string | number | boolean} | {location: string} | {callbackUrl: string}] 
   isAsync: boolean;
 };
 
 export const handleLocation = async (
-  ctx: Koa.ParameterizedContext,
-  data: {
+    ctx: Koa.ParameterizedContext,
+    data: {
     clients: { [key: string]: DVCClient };
     users: { [key: string]: DVCUser };
   }
 ) => {
-  const body = ctx.request.body as LocationRequestBody;
-  const urlParts = ctx.request.url.split("/");
-  console.log(urlParts);
-  let entity = getEntityFromLocation(ctx.request.url, data);
-  console.log("entity", entity);
+    const body = ctx.request.body as LocationRequestBody
+    const urlParts = ctx.request.url.split('/')
+    console.log(urlParts)
+    const entity = getEntityFromLocation(ctx.request.url, data)
+    console.log('entity', entity)
 
-  if (entity === undefined) {
-    ctx.status = 400;
-    ctx.body = {
-      errorCode: 400,
-      errorMessage: "Invalid request: missing entity",
-    };
-  } else if (body.command === undefined) {
-    ctx.status = 400;
-    ctx.body = {
-      errorCode: 400,
-      errorMessage: "Invalid request: missing command",
-    };
-  } else {
-    try {
-      const command = body.command;
-      const params: any | string | boolean | number = parseParams(
-        JSON.parse(body.params),
-        data
-      );
-
-      // TODO: handle async commands
-      // TODO: handle callback before invoking command
-      const resultData = await invokeCommand(
-        entity,
-        command,
-        params,
-        body.isAsync
-      );
-
-      ctx.status = 200;
-      ctx.body = {
-        entityType: convertEntityTypes(resultData.constructor.name), // assuming this is the type of the entity for returned data
-        data: resultData,
-        logs: [], // TODO add logs here
-      };
-    } catch (error) {
-      if (body.isAsync) {
-        ctx.status = 200;
+    if (entity === undefined) {
+        ctx.status = 400
         ctx.body = {
-          asyncError: error.message,
-          errorCode: error.code,
-        };
-      } else {
-        ctx.status = 200;
+            errorCode: 400,
+            errorMessage: 'Invalid request: missing entity',
+        }
+    } else if (body.command === undefined) {
+        ctx.status = 400
         ctx.body = {
-          errorCode: error.code,
-          exception: error.message,
-        };
-      }
+            errorCode: 400,
+            errorMessage: 'Invalid request: missing command',
+        }
+    } else {
+        try {
+            const command = body.command
+            const params: any | string | boolean | number = parseParams(
+                JSON.parse(body.params),
+                data
+            )
+
+            // TODO: handle async commands
+            // TODO: handle callback before invoking command
+            const resultData = await invokeCommand(
+                entity,
+                command,
+                params,
+                body.isAsync
+            )
+
+            ctx.status = 200
+            ctx.body = {
+                entityType: convertEntityTypes(resultData.constructor.name),
+                data: resultData,
+                logs: [], // TODO add logs here
+            }
+        } catch (error) {
+            if (body.isAsync) {
+                ctx.status = 200
+                ctx.body = {
+                    asyncError: error.message,
+                    errorCode: error.code,
+                }
+            } else {
+                ctx.status = 200
+                ctx.body = {
+                    errorCode: error.code,
+                    exception: error.message,
+                }
+            }
+        }
     }
-  }
-};
+}
 
 const getEntityFromLocation = (location, data) => {
-  const urlParts = location.split("/");
-  const entityType = urlParts[urlParts.length - 2];
-  const id = urlParts[urlParts.length - 1];
-  let entity;
-  if (entityType === "user") {
-    entity = data.users[id];
-  }
-  if (entityType === "client") {
-    entity = data.clients[id];
-  }
-  return entity;
-};
+    const urlParts = location.split('/')
+    const entityType = urlParts[urlParts.length - 2]
+    const id = urlParts[urlParts.length - 1]
+    let entity
+    if (entityType === 'user') {
+        entity = data.users[id]
+    }
+    if (entityType === 'client') {
+        entity = data.clients[id]
+    }
+    return entity
+}
 
 const parseParams = (params, data): (string | boolean | number | any)[] => {
-  const parsedParams: (string | boolean | number | any)[] = [];
-  params.forEach((element) => {
-    if (element.value !== undefined) {
-      parsedParams.push(element.value);
-    } else if (element.location !== undefined) {
-      parsedParams.push(getEntityFromLocation(element.location, data));
-    }
-  });
-  return parsedParams;
-};
+    const parsedParams: (string | boolean | number | any)[] = []
+    params.forEach((element) => {
+        if (element.value !== undefined) {
+            parsedParams.push(element.value)
+        } else if (element.location !== undefined) {
+            parsedParams.push(getEntityFromLocation(element.location, data))
+        }
+    })
+    return parsedParams
+}
 
 const invokeCommand = async (entity, command, params, isAsync) => {
-  if (isAsync) {
-    const result = await entity[command](...params);
-    return result;
-  }
-  {
-    return entity[command](...params);
-  }
-};
+    if (isAsync) {
+        const result = await entity[command](...params)
+        return result
+    }
+    {
+        return entity[command](...params)
+    }
+}

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -33,19 +33,19 @@ export const handleLocation = async (
 
         const entityType = getEntityFromType(resultData.constructor.name)
 
-        const commandId = data.commandResults[entityType.model] !== undefined ?
-            Object.keys(data.commandResults[entityType.model]).length :
+        const commandId = data.commandResults[entityType.toLowerCase()] !== undefined ?
+            Object.keys(data.commandResults[entityType.toLowerCase()]).length :
             0
 
-        if (data.commandResults[entityType.model] === undefined) {
-            data.commandResults[entityType.model] = {}
+        if (data.commandResults[entityType.toLowerCase()] === undefined) {
+            data.commandResults[entityType.toLowerCase()] = {}
         }
-        data.commandResults[entityType.model][commandId] = resultData
+        data.commandResults[entityType.toLowerCase()][commandId] = resultData
 
         ctx.status = 200
-        ctx.set('Location', `command/${entityType.model}/${commandId}`)
+        ctx.set('Location', `command/${entityType.toLowerCase()}/${commandId}`)
         ctx.body = {
-            entityType: entityType.type,
+            entityType: entityType,
             data: resultData,
             logs: [], // TODO add logs here
         }

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -95,10 +95,17 @@ const getEntityFromLocation = (location: string, data: Data) => {
         }
         return entity
     } else if (urlParts.length === 4) {
-        const command = urlParts[urlParts.length - 2]
+        const command = urlParts[urlParts.length - 3]
         const entityType = urlParts[urlParts.length - 2]
         const id = urlParts[urlParts.length - 1]
-        return data[command][entityType][id]
+        console.log('command: ', command)
+        if (command === 'command') {
+            console.log('data: ', data)
+            console.log('commandResults: ', data.commandResults)
+            console.log('entityType: ', data.commandResults[entityType])
+            console.log('id: ', data.commandResults[entityType][id])
+            return data.commandResults[entityType][id]
+        }
     }
     return undefined
 }
@@ -124,6 +131,9 @@ const invokeCommand = async (
         const result = await entity[command](...params)
         return result
     }
+    console.log('entity: ', entity)
+    console.log('command: ', command)
+    console.log('fn: ', entity[command])
     return entity[command](...params)
 
 }

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -1,3 +1,4 @@
+import { DVCClient, DVCUser, DVCVariable } from '@devcycle/nodejs-server-sdk'
 import Koa from 'koa'
 import { getEntityFromType, Data } from '../entityTypes'
 
@@ -8,16 +9,18 @@ type LocationRequestBody = {
     isAsync: boolean
 }
 
+type parsedParams = (string | boolean | number | object)[];
+
 export const handleLocation = async (
     ctx: Koa.ParameterizedContext,
     data: Data,
     body: LocationRequestBody,
-    entity: any
+    entity: DVCClient | DVCUser | DVCVariable | any
 ) => {
 
     try {
         const command = body.command
-        const params: string | boolean | number | object = parseParams(
+        const params: parsedParams = parseParams(
             JSON.parse(body.params),
             data
         )
@@ -71,7 +74,7 @@ export const handleLocation = async (
     }
 }
 
-const getEntityFromLocation = (location, data) => {
+const getEntityFromLocation = (location: string, data: Data) => {
     const urlParts = location.split('/')
 
     /**
@@ -100,8 +103,8 @@ const getEntityFromLocation = (location, data) => {
     return undefined
 }
 
-const parseParams = (params, data): (string | boolean | number | any)[] => {
-    const parsedParams: (string | boolean | number | object)[] = []
+const parseParams = (params: object | any, data: Data): parsedParams => {
+    const parsedParams: parsedParams = []
     params.forEach((element) => {
         if (element.value !== undefined) {
             parsedParams.push(element.value)
@@ -112,7 +115,11 @@ const parseParams = (params, data): (string | boolean | number | any)[] => {
     return parsedParams
 }
 
-const invokeCommand = async (entity, command, params, isAsync) => {
+const invokeCommand = async (
+    entity: DVCClient | DVCUser | DVCVariable | any,
+    command: string,
+    params: parsedParams,
+    isAsync: boolean) => {
     if (isAsync) {
         const result = await entity[command](...params)
         return result

--- a/proxies/nodejs/handlers/user.ts
+++ b/proxies/nodejs/handlers/user.ts
@@ -1,19 +1,19 @@
 import Koa from 'koa'
-import { DVCUser } from "@devcycle/nodejs-server-sdk"
-import { EntityTypes } from "../entityTypes"
+import { DVCUser } from '@devcycle/nodejs-server-sdk'
+import { EntityTypes } from '../entityTypes'
 
 export const handleUser = async (ctx: Koa.ParameterizedContext, users: { [key: string]: DVCUser }) => {
-  const user = <DVCUser>ctx.request.body
+    const user = <DVCUser>ctx.request.body
 
-  const userId = Object.keys(users).length
-  users[userId] = user
+    const userId = Object.keys(users).length
+    users[userId] = user
 
-  ctx.status = 201
-  ctx.set("Location", `user/${userId}`)
-  ctx.body = {
-    entityType: EntityTypes.user,
-    data: {
-      ...user
+    ctx.status = 201
+    ctx.set('Location', `user/${userId}`)
+    ctx.body = {
+        entityType: EntityTypes.user,
+        data: {
+            ...user
+        }
     }
-  }
 }


### PR DESCRIPTION
- call methods and format return values
- assumptions: 
  - the call will only be made on `client` and `user` at the moment, 
  - callbacks not yet supported 
  - the POST `/location` call is being on a function that exists on the type
  - entityType just shows object, will be accurate after all object types are well defined 
  
  Tested on the following test data:
  
  ```js
      const testClientData = [
      {
        "clientId": 1,
        "sdkKey": "<SDKKEY>",
        "options": {},
      },
      {
        clientId: 2,
        sdkKey: "<SDKKEY>",
        options: {},
      }
    ]

    const testUserData = [
      {
        "user_id": "1",
        "name": "user1",
        isAnonymous: false,
      },
      {
        "user_id": "2",
        "name": "user2",
        isAnonymous: false,
      }
    ]
    testClientData.forEach(async (clientData) => {
      const client = await initialize(clientData.sdkKey, clientData.options).onClientInitialized()
      data.clients[clientData.clientId] = client
    }) 
    testUserData.forEach(async (userData) => {
      const user = <DVCUser>userData
      const userId = Object.keys(data.users).length
      data.users[userId] = user
    })

  ```
  using the following call:
  ```
  POST localhost:3000/client/2
  body : {
    command: variable
    params:[{"location": "user/1"},{"value": "variable-key"},{"value":"defaultValue"},{"callbackURL": "call back url string here"}]
  }
  ```
  