### PR TITLE
add callback to the passed string

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,6 +1,8 @@
-name: Node.js CI
+name: Run Harness Tests
 
 on:
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       sdk:
@@ -9,14 +11,19 @@ on:
       sha:
         type: string
         description: The SHA that triggered this test harness run
-jobs:
-  build:
-    runs-on: ubuntu-latest
 
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    name: Run Tests
     steps:
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - uses: actions/checkout@v3
-    - run: yarn
-    - run: yarn test
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Dependencies
+        run: yarn
+      - name: Run All Tests
+        run: yarn test

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -1,10 +1,10 @@
-import { DVCClient, DVCUser } from "@devcycle/nodejs-server-sdk";
-import Koa from "koa";
-import Router from "koa-router";
-import bodyParser from "koa-bodyparser";
-import { handleUser } from "./handlers/user";
-import { handleClient } from "./handlers/client";
-import { handleLocation } from "./handlers/location";
+import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
+import Koa from 'koa'
+import Router from 'koa-router'
+import bodyParser from 'koa-bodyparser'
+import { handleUser } from './handlers/user'
+import { handleClient } from './handlers/client'
+import { handleLocation } from './handlers/location'
 
 type Data = {
   clients: { [key: string]: DVCClient };
@@ -13,14 +13,14 @@ type Data = {
 };
 
 const data: Data = {
-  clients: {},
-  users: {},
-  commandResults: {},
-};
+    clients: {},
+    users: {},
+    commandResults: {},
+}
 
 async function start() {
-  const app = new Koa();
-  app.use(bodyParser());
+    const app = new Koa()
+    app.use(bodyParser())
 
     const router = new Router()
 
@@ -33,30 +33,18 @@ async function start() {
         }
     })
 
-<<<<<<< HEAD
     router.post('/client', (ctx: Koa.ParameterizedContext) => {
         handleClient(ctx, data.clients)
     })
     router.post('/user', (ctx: Koa.ParameterizedContext) => {
         handleUser(ctx, data.users)
     })
-=======
-  router.post("/client", (ctx: Koa.ParameterizedContext) => {
-    handleClient(ctx, data.clients);
-  });
-  router.post("/user", (ctx: Koa.ParameterizedContext) => {
-    handleUser(ctx, data.users);
-  });
-  router.post("/:location*", (ctx: Koa.ParameterizedContext) => {
-    handleLocation(ctx, data);
-  });
->>>>>>> 0863145 (move code to handler file)
 
-  app.use(router.routes()).use(router.allowedMethods());
+    app.use(router.routes()).use(router.allowedMethods())
 
-  // Server!
-  console.log("Server started on port 3000");
-  app.listen(3000);
+    // Server!
+    console.log('Server started on port 3000')
+    app.listen(3000)
 }
 
-start();
+start()

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -1,25 +1,25 @@
-import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
-import Koa from 'koa'
-import Router from 'koa-router'
-import bodyParser from 'koa-bodyparser'
-import { handleUser } from './handlers/user'
-import { handleClient } from './handlers/client'
+import { DVCClient, DVCUser } from "@devcycle/nodejs-server-sdk";
+import Koa from "koa";
+import Router from "koa-router";
+import bodyParser from "koa-bodyparser";
+import { handleUser } from "./handlers/user";
+import { handleClient } from "./handlers/client";
 
 type Data = {
-  clients: { [key: string]: DVCClient }
-  users: { [key: string]: DVCUser }
-  commandResults: { [key: string]: any }
-}
+  clients: { [key: string]: DVCClient };
+  users: { [key: string]: DVCUser };
+  commandResults: { [key: string]: any };
+};
 
 const data: Data = {
-    clients: {},
-    users: {},
-    commandResults: {}
-}
+  clients: {},
+  users: {},
+  commandResults: {},
+};
 
 async function start() {
-    const app = new Koa()
-    app.use(bodyParser())
+  const app = new Koa();
+  app.use(bodyParser());
 
     const router = new Router()
 
@@ -39,11 +39,11 @@ async function start() {
         handleUser(ctx, data.users)
     })
 
-    app.use(router.routes()).use(router.allowedMethods())
+  app.use(router.routes()).use(router.allowedMethods());
 
-    // Server!
-    console.log('Server started on port 3000')
-    app.listen(3000)
+  // Server!
+  console.log("Server started on port 3000");
+  app.listen(3000);
 }
 
-start()
+start();

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -4,6 +4,7 @@ import Router from "koa-router";
 import bodyParser from "koa-bodyparser";
 import { handleUser } from "./handlers/user";
 import { handleClient } from "./handlers/client";
+import { handleLocation } from "./handlers/location";
 
 type Data = {
   clients: { [key: string]: DVCClient };
@@ -37,6 +38,9 @@ async function start() {
   });
   router.post("/user", (ctx: Koa.ParameterizedContext) => {
     handleUser(ctx, data.users);
+  });
+  router.post("/:location*", (ctx: Koa.ParameterizedContext) => {
+    handleLocation(ctx, data);
   });
 
   app.use(router.routes()).use(router.allowedMethods());

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -4,6 +4,7 @@ import Router from "koa-router";
 import bodyParser from "koa-bodyparser";
 import { handleUser } from "./handlers/user";
 import { handleClient } from "./handlers/client";
+import { handleLocation } from "./handlers/location";
 
 type Data = {
   clients: { [key: string]: DVCClient };
@@ -32,12 +33,24 @@ async function start() {
         }
     })
 
+<<<<<<< HEAD
     router.post('/client', (ctx: Koa.ParameterizedContext) => {
         handleClient(ctx, data.clients)
     })
     router.post('/user', (ctx: Koa.ParameterizedContext) => {
         handleUser(ctx, data.users)
     })
+=======
+  router.post("/client", (ctx: Koa.ParameterizedContext) => {
+    handleClient(ctx, data.clients);
+  });
+  router.post("/user", (ctx: Koa.ParameterizedContext) => {
+    handleUser(ctx, data.users);
+  });
+  router.post("/:location*", (ctx: Koa.ParameterizedContext) => {
+    handleLocation(ctx, data);
+  });
+>>>>>>> 0863145 (move code to handler file)
 
   app.use(router.routes()).use(router.allowedMethods());
 

--- a/proxies/nodejs/app.ts
+++ b/proxies/nodejs/app.ts
@@ -1,10 +1,9 @@
-import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
-import Koa from 'koa'
-import Router from 'koa-router'
-import bodyParser from 'koa-bodyparser'
-import { handleUser } from './handlers/user'
-import { handleClient } from './handlers/client'
-import { handleLocation } from './handlers/location'
+import { DVCClient, DVCUser } from "@devcycle/nodejs-server-sdk";
+import Koa from "koa";
+import Router from "koa-router";
+import bodyParser from "koa-bodyparser";
+import { handleUser } from "./handlers/user";
+import { handleClient } from "./handlers/client";
 
 type Data = {
   clients: { [key: string]: DVCClient };
@@ -13,38 +12,38 @@ type Data = {
 };
 
 const data: Data = {
-    clients: {},
-    users: {},
-    commandResults: {},
-}
+  clients: {},
+  users: {},
+  commandResults: {},
+};
 
 async function start() {
-    const app = new Koa()
-    app.use(bodyParser())
+  const app = new Koa();
+  app.use(bodyParser());
 
-    const router = new Router()
+  const router = new Router();
 
-    router.get('/spec', (ctx) => {
-        ctx.status = 200
-        ctx.body = {
-            name: 'NodeJS',
-            version: '', // TODO add branch name or sdk version here
-            capabilities: ['EdgeDB', 'LocalBucketing'],
-        }
-    })
+  router.get("/spec", (ctx) => {
+    ctx.status = 200;
+    ctx.body = {
+      name: "NodeJS",
+      version: "", // TODO add branch name or sdk version here
+      capabilities: ["EdgeDB", "LocalBucketing"],
+    };
+  });
 
-    router.post('/client', (ctx: Koa.ParameterizedContext) => {
-        handleClient(ctx, data.clients)
-    })
-    router.post('/user', (ctx: Koa.ParameterizedContext) => {
-        handleUser(ctx, data.users)
-    })
+  router.post("/client", (ctx: Koa.ParameterizedContext) => {
+    handleClient(ctx, data.clients);
+  });
+  router.post("/user", (ctx: Koa.ParameterizedContext) => {
+    handleUser(ctx, data.users);
+  });
 
-    app.use(router.routes()).use(router.allowedMethods())
+  app.use(router.routes()).use(router.allowedMethods());
 
-    // Server!
-    console.log('Server started on port 3000')
-    app.listen(3000)
+  // Server!
+  console.log("Server started on port 3000");
+  app.listen(3000);
 }
 
-start()
+start();

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -1,0 +1,69 @@
+import Koa from 'koa'
+import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
+
+type LocationRequestBody = {
+    command: string
+    params: string //[{value: string | number | boolean} | {location: string} | {callbackUrl: string}] HTTP request comes in as string
+    isAsync: boolean
+  }
+
+export const handleLocation = async (ctx:Koa.ParameterizedContext, data: {clients: { [key: string]: DVCClient }, users: { [key: string]: DVCUser }}) => {
+    const body = ctx.request.body as LocationRequestBody
+    const urlParts = ctx.request.url.split('/')
+    console.log(urlParts)
+    let entity = getEntityFromLocation(ctx.request.url, data);
+    console.log("entity", entity)
+  
+    if(entity === undefined){
+      ctx.status = 400
+      ctx.body = {
+        errorCode: 400,
+        errorMessage: "Invalid request: missing entity"
+      }
+    } else if (body.command === undefined){
+      ctx.status = 400
+      ctx.body = {
+        errorCode: 400, 
+        errorMessage: "Invalid request: missing command"
+  
+      }
+    } else {
+      const command = body.command;
+      const params: (any|string|boolean|number) = parseParams(JSON.parse(body.params), data);
+      const resultData = entity[command](...params);
+    
+      ctx.status = 200
+      ctx.body = {
+        entityType: typeof(resultData),
+        data: resultData,
+        logs: [] // TODO add logs here
+      }
+    }
+  }
+  
+  const getEntityFromLocation = (location, data) => {
+    const urlParts = location.split('/')
+    const entityType = urlParts[urlParts.length - 2]
+    const id = urlParts[urlParts.length - 1]
+    let entity;
+    if(entityType === "user"){
+      entity = data.users[id];
+    }
+    if(entityType === "client"){
+      entity = data.clients[id];
+    }
+    return entity;
+  }
+  
+  const parseParams = (params, data):(string | boolean | number | any)[] => {
+    const parsedParams :(string| boolean| number| any)[] = [];
+    params.forEach(element => {
+      if(element.value !== undefined){
+        parsedParams.push(element.value);
+      } else if(element.location !== undefined){
+        parsedParams.push(getEntityFromLocation(element.location, data))
+      }
+    });
+    return parsedParams;
+  }
+  

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -1,69 +1,92 @@
-import Koa from 'koa'
-import { DVCClient, DVCUser } from '@devcycle/nodejs-server-sdk'
+import Koa from "koa";
+import { DVCClient, DVCUser } from "@devcycle/nodejs-server-sdk";
 
 type LocationRequestBody = {
-    command: string
-    params: string //[{value: string | number | boolean} | {location: string} | {callbackUrl: string}] HTTP request comes in as string
-    isAsync: boolean
-  }
+  command: string;
+  params: string; //[{value: string | number | boolean} | {location: string} | {callbackUrl: string}] HTTP request comes in as string
+  isAsync: boolean;
+};
 
-export const handleLocation = async (ctx:Koa.ParameterizedContext, data: {clients: { [key: string]: DVCClient }, users: { [key: string]: DVCUser }}) => {
-    const body = ctx.request.body as LocationRequestBody
-    const urlParts = ctx.request.url.split('/')
-    console.log(urlParts)
-    let entity = getEntityFromLocation(ctx.request.url, data);
-    console.log("entity", entity)
-  
-    if(entity === undefined){
-      ctx.status = 400
-      ctx.body = {
-        errorCode: 400,
-        errorMessage: "Invalid request: missing entity"
-      }
-    } else if (body.command === undefined){
-      ctx.status = 400
-      ctx.body = {
-        errorCode: 400, 
-        errorMessage: "Invalid request: missing command"
-  
-      }
-    } else {
+export const handleLocation = async (
+  ctx: Koa.ParameterizedContext,
+  data: {
+    clients: { [key: string]: DVCClient };
+    users: { [key: string]: DVCUser };
+  }
+) => {
+  const body = ctx.request.body as LocationRequestBody;
+  const urlParts = ctx.request.url.split("/");
+  console.log(urlParts);
+  let entity = getEntityFromLocation(ctx.request.url, data);
+  console.log("entity", entity);
+
+  if (entity === undefined) {
+    ctx.status = 400;
+    ctx.body = {
+      errorCode: 400,
+      errorMessage: "Invalid request: missing entity",
+    };
+  } else if (body.command === undefined) {
+    ctx.status = 400;
+    ctx.body = {
+      errorCode: 400,
+      errorMessage: "Invalid request: missing command",
+    };
+  } else {
+    try {
       const command = body.command;
-      const params: (any|string|boolean|number) = parseParams(JSON.parse(body.params), data);
+      const params: any | string | boolean | number = parseParams(
+        JSON.parse(body.params),
+        data
+      );
       const resultData = entity[command](...params);
-    
-      ctx.status = 200
+
+      ctx.status = 200;
       ctx.body = {
-        entityType: typeof(resultData),
+        entityType: typeof resultData,
         data: resultData,
-        logs: [] // TODO add logs here
+        logs: [], // TODO add logs here
+      };
+    } catch (error) {
+      if (body.isAsync) {
+        ctx.status = 202;
+        ctx.body = {
+          asyncError: error.message,
+          errorCode: error.code,
+        };
+      } else {
+        ctx.status = 200;
+        ctx.body = {
+          errorCode: 200,
+          exception: error.message,
+        };
       }
     }
   }
-  
-  const getEntityFromLocation = (location, data) => {
-    const urlParts = location.split('/')
-    const entityType = urlParts[urlParts.length - 2]
-    const id = urlParts[urlParts.length - 1]
-    let entity;
-    if(entityType === "user"){
-      entity = data.users[id];
-    }
-    if(entityType === "client"){
-      entity = data.clients[id];
-    }
-    return entity;
+};
+
+const getEntityFromLocation = (location, data) => {
+  const urlParts = location.split("/");
+  const entityType = urlParts[urlParts.length - 2];
+  const id = urlParts[urlParts.length - 1];
+  let entity;
+  if (entityType === "user") {
+    entity = data.users[id];
   }
-  
-  const parseParams = (params, data):(string | boolean | number | any)[] => {
-    const parsedParams :(string| boolean| number| any)[] = [];
-    params.forEach(element => {
-      if(element.value !== undefined){
-        parsedParams.push(element.value);
-      } else if(element.location !== undefined){
-        parsedParams.push(getEntityFromLocation(element.location, data))
-      }
-    });
-    return parsedParams;
+  if (entityType === "client") {
+    entity = data.clients[id];
   }
-  
+  return entity;
+};
+
+const parseParams = (params, data): (string | boolean | number | any)[] => {
+  const parsedParams: (string | boolean | number | any)[] = [];
+  params.forEach((element) => {
+    if (element.value !== undefined) {
+      parsedParams.push(element.value);
+    } else if (element.location !== undefined) {
+      parsedParams.push(getEntityFromLocation(element.location, data));
+    }
+  });
+  return parsedParams;
+};

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -43,7 +43,10 @@ export const handleLocation = async (
       if (params[params.length - 1] instanceof URL) {
         const callbackURL: URL = params[params.length - 1];
         const onUpdateCallback = (data) => {
-          axios.post(callbackURL.href, data); // send back the update data
+          axios
+            .post(callbackURL.href, { data: data }) //send back the updated data
+            .then((resp) => console.log("onUpdatecallback resp ", resp))
+            .catch((e) => console.error(e));
         };
         invokeCommand(entity, command, params, body.isAsync).then((data) => {
           console.log("data", data);

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -42,7 +42,12 @@ export const handleLocation = async (
 
       // TODO: handle async commands
       // TODO: handle callback before invoking command
-      const resultData = entity[command](...params);
+      const resultData = await invokeCommand(
+        entity,
+        command,
+        params,
+        body.isAsync
+      );
 
       ctx.status = 200;
       ctx.body = {
@@ -92,4 +97,14 @@ const parseParams = (params, data): (string | boolean | number | any)[] => {
     }
   });
   return parsedParams;
+};
+
+const invokeCommand = async (entity, command, params, isAsync) => {
+  if (isAsync) {
+    const result = await entity[command](...params);
+    return result;
+  }
+  {
+    return entity[command](...params);
+  }
 };

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -46,19 +46,19 @@ export const handleLocation = async (
 
       ctx.status = 200;
       ctx.body = {
-        entityType: typeof resultData, // assuming this is the type of the entity for returned data
+        entityType: resultData.constructor.name, // assuming this is the type of the entity for returned data
         data: resultData,
         logs: [], // TODO add logs here
       };
     } catch (error) {
       if (body.isAsync) {
-        ctx.status = 500;
+        ctx.status = 200;
         ctx.body = {
           asyncError: error.message,
           errorCode: error.code,
         };
       } else {
-        ctx.status = 500;
+        ctx.status = 200;
         ctx.body = {
           errorCode: error.code,
           exception: error.message,

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -39,11 +39,14 @@ export const handleLocation = async (
         JSON.parse(body.params),
         data
       );
+
+      // TODO: handle async commands
+      // TODO: handle callback before invoking command
       const resultData = entity[command](...params);
 
       ctx.status = 200;
       ctx.body = {
-        entityType: typeof resultData,
+        entityType: typeof resultData, // assuming this is the type of the entity for returned data
         data: resultData,
         logs: [], // TODO add logs here
       };

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -52,15 +52,15 @@ export const handleLocation = async (
       };
     } catch (error) {
       if (body.isAsync) {
-        ctx.status = 202;
+        ctx.status = 500;
         ctx.body = {
           asyncError: error.message,
           errorCode: error.code,
         };
       } else {
-        ctx.status = 200;
+        ctx.status = 500;
         ctx.body = {
-          errorCode: 200,
+          errorCode: error.code,
           exception: error.message,
         };
       }


### PR DESCRIPTION
since there are no callback parameters for the nodejs sdk, `.then()` seems to be the best way to initial callback to the URL

test data:
```
  const testClientData = [
    {
      clientId: 1,
      sdkKey: "SDK_KEY",
      options: {},
    },
    {
      clientId: 2,
      sdkKey: "SDK_KEY",
      options: {},
    },
  ];

  const testUserData = [
    {
      user_id: "1",
      name: "user1",
      isAnonymous: false,
    },
    {
      user_id: "2",
      name: "user2",
      isAnonymous: false,
    },
  ];
  testClientData.forEach(async (clientData) => {
    const client = await initialize(
      clientData.sdkKey,
      clientData.options
    ).onClientInitialized();
    data.clients[clientData.clientId] = client;
  });
  testUserData.forEach(async (userData) => {
    const user = <DVCUser>userData;
    const userId = Object.keys(data.users).length;
    data.users[userId] = user;
  });

  router.post("/update", (ctx) => {
    console.log(ctx);
    ctx.status = 200;
    ctx.body = {
      data: "update",
    };
  });

```

test call: 
```
POST localhost:3000/client/2
body : {
  command: variable
  params:[{"location": "user/1"},{"value": "variable-key"},{"value":"defaultValue"},{"callbackURL": "localhost:8000/update"}]
}
```

setup a test express server on `PORT 8000` to capture the calback