### PR TITLE
feat: checkout sha of node js sdk if given from workflow

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -19,6 +19,12 @@ jobs:
     env:
       DOCKER_HOST_IP: '172.17.0.1'
     steps:
+      - name: Write variables to .env file
+        run: |
+          if [ -f ".env" ]
+          then 
+              echo "GITHUB_SHA=${{ github.event.inputs.sha }}" > ".env"
+          fi
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -23,7 +23,8 @@ jobs:
         run: |
           if [ -f ".env" ]
           then 
-              echo "GITHUB_SHA=${{ github.event.inputs.sha }}" > ".env"
+              echo "GITHUB_SHA='${{ github.event.inputs.sha }}'" > ".env"
+              echo "SDKS_TO_TEST='${{ github.event.inputs.sdk }}'" > ".env"
           fi
       - uses: actions/setup-node@v3
         with:

--- a/ci-config.js
+++ b/ci-config.js
@@ -1,1 +1,0 @@
-process.env.DOCKER_HOST_IP='172.17.0.1'

--- a/ci-config.ts
+++ b/ci-config.ts
@@ -1,0 +1,4 @@
+import * as dotenv from 'dotenv'
+dotenv.config()
+
+process.env.DOCKER_HOST_IP='172.17.0.1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: ./proxies/nodejs
       args:
         - NODEJS_SDK_VERSION=${NODEJS_SDK_VERSION}
+        - GITHUB_SHA=${GITHUB_SHA}
     container_name: nodejs
     ports:
       - "3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       args:
         - NODEJS_SDK_VERSION=${NODEJS_SDK_VERSION}
         - GITHUB_SHA=${GITHUB_SHA}
+        - SDKS_TO_TEST=${SDKS_TO_TEST}
     container_name: nodejs
     ports:
       - "3000"

--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -19,7 +19,7 @@ const scope = getServerScope()
 describe('Variable Tests - Cloud', () => {
     forEachSDK((name) => {
         let url: string
-        const capabilities: string[] = SDKCapabilities[name]
+        const capabilities: string[] = SDKCapabilities[name] || []
         const clientId: string = uuidv4()
         const sdkKey: string = `dvc_server_${clientId}`
         const mockServerUrl

--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -19,7 +19,7 @@ const scope = getServerScope()
 describe('Variable Tests - Cloud', () => {
     forEachSDK((name) => {
         let url: string
-        const capabilities: string[] = SDKCapabilities[name] || []
+        const capabilities: string[] = SDKCapabilities[name]
         const clientId: string = uuidv4()
         const sdkKey: string = `dvc_server_${clientId}`
         const mockServerUrl

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -17,10 +17,14 @@ export const forEachSDK = (tests) => {
     // get the list of SDK's and their capabilities
     let SDKs
     try {
-        SDKs = JSON.parse(process.env.SDKS_TO_TEST)
+        SDKs = JSON.parse(process.env.SDKS_TO_TEST).map((sdk) => Sdks[sdk])
     } catch (e) {
-        console.log('No specified SDKs to test, running all tests')
-        SDKs = Object.values(Sdks)
+        if (process.env.SDKS_TO_TEST) {
+            SDKs = [process.env.SDKS_TO_TEST]
+        } else {
+            console.log('No specified SDKs to test, running all tests')
+            SDKs = Object.values(Sdks)
+        }
     }
     const scope = getServerScope()
 

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -19,8 +19,8 @@ export const forEachSDK = (tests) => {
     try {
         SDKs = JSON.parse(process.env.SDKS_TO_TEST).map((sdk) => Sdks[sdk])
     } catch (e) {
-        if (process.env.SDKS_TO_TEST) {
-            SDKs = [process.env.SDKS_TO_TEST]
+        if (process.env.SDKS_TO_TEST && Sdks[process.env.SDKS_TO_TEST]) {
+            SDKs = [Sdks[process.env.SDKS_TO_TEST]]
         } else {
             console.log('No specified SDKs to test, running all tests')
             SDKs = Object.values(Sdks)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@devcycle/test-harness",
   "scripts": {
     "test": "jest --verbose",
-    "test:ci": "yarn test --setupFiles=./ci-config.js"
+    "test:ci": "yarn test --setupFiles=./ci-config.ts"
   },
   "version": "1.0.0",
   "description": "A universal testing system for DevCycle SDKs",
@@ -29,6 +29,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
+    "dotenv": "^16.0.3",
     "uuid": "^9.0.0"
   },
   "lint-staged": {

--- a/proxies/nodejs/Dockerfile
+++ b/proxies/nodejs/Dockerfile
@@ -2,11 +2,14 @@ FROM node:lts-alpine
 ARG NODEJS_SDK_VERSION
 ENV NODEJS_SDK_VERSION $NODEJS_SDK_VERSION
 
+ARG GITHUB_SHA
+ENV GITHUB_SHA $GITHUB_SHA
+
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . /app
 WORKDIR /app
 RUN yarn
-RUN ./install.sh
+RUN ./install.sh 
 ENTRYPOINT yarn ts-node app.ts

--- a/proxies/nodejs/Dockerfile
+++ b/proxies/nodejs/Dockerfile
@@ -5,6 +5,9 @@ ENV NODEJS_SDK_VERSION $NODEJS_SDK_VERSION
 ARG GITHUB_SHA
 ENV GITHUB_SHA $GITHUB_SHA
 
+ARG SDKS_TO_TEST
+ENV SDKS_TO_TEST $SDKS_TO_TEST
+
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 

--- a/proxies/nodejs/install.sh
+++ b/proxies/nodejs/install.sh
@@ -1,4 +1,12 @@
-if [ -z "$NODEJS_SDK_VERSION" ]; then
+if [ "GITHUB_SHA" ]; then
+    git clone https://github.com/DevCycleHQ/js-sdks.git
+    cd js-sdks
+    git checkout $GITHUB_SHA
+    yarn
+    NX_DAEMON=false yarn nx build nodejs --verbose
+    cd ..
+    yarn add file:js-sdks/dist/sdk/nodejs/
+elif [ -z "$NODEJS_SDK_VERSION" ]; then
     yarn add @devcycle/nodejs-server-sdk
 else
     yarn add @devcycle/nodejs-server-sdk@$NODEJS_SDK_VERSION

--- a/proxies/nodejs/install.sh
+++ b/proxies/nodejs/install.sh
@@ -1,4 +1,4 @@
-if [ "GITHUB_SHA" ]; then
+if [ -n "$GITHUB_SHA" ] && [[ "$SDKS_TO_TEST" =~ .*"nodejs"* ]]; then
     git clone https://github.com/DevCycleHQ/js-sdks.git
     cd js-sdks
     git checkout $GITHUB_SHA
@@ -6,6 +6,8 @@ if [ "GITHUB_SHA" ]; then
     NX_DAEMON=false yarn nx build nodejs --verbose
     cd ..
     yarn add file:js-sdks/dist/sdk/nodejs/
+    yarn add file:js-sdks/lib/shared/bucketing-assembly-script/
+    yarn add file:js-sdks/lib/shared/types/
 elif [ -z "$NODEJS_SDK_VERSION" ]; then
     yarn add @devcycle/nodejs-server-sdk
 else

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,6 +1491,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"


### PR DESCRIPTION
# Summary

If a sha has been passed in from `workflow_dispatch`, then we write it to an `.env` file and use it to checkout a specific commit of the nodejs sdk and install that version after building with nx