### PR TITLE
Add cloud test client helper

### DIFF
--- a/harness/features/allFeatures.local.test.ts
+++ b/harness/features/allFeatures.local.test.ts
@@ -1,9 +1,9 @@
-import { 
-    getConnectionStringForProxy, 
-    forEachSDK, 
-    describeIf, 
+import {
+    getConnectionStringForProxy,
+    forEachSDK,
+    describeIf,
     createUser,
-    TestClient,
+    LocalTestClient,
     waitForRequest
 } from '../helpers'
 import { Capabilities, SDKCapabilities } from '../types'
@@ -18,14 +18,14 @@ describe('allFeatures Tests - Local', () => {
     forEachSDK((name) => {
         let url: string
         const capabilities: string[] = SDKCapabilities[name]
-        
+
         let variationOnUser: string
         let noVariationUser: string
         let invalidUser: string
 
         beforeAll(async () => {
-            url = getConnectionStringForProxy(name)  
-            
+            url = getConnectionStringForProxy(name)
+
             variationOnUser = (
                 await createUser(url, { user_id: 'user1', customData: { 'should-bucket': true } })
             ).headers.get('location')
@@ -41,16 +41,16 @@ describe('allFeatures Tests - Local', () => {
 
         describeIf(capabilities.includes(Capabilities.local))(name, () => {
             describe('uninitialized client', () => {
-                const testClient = new TestClient(name)
+                const testClient = new LocalTestClient(name)
 
                 beforeAll(async () => {
                     await testClient.createClient()
                     const configRequestUrl = `/${testClient.clientLocation}/config/v1/server/${testClient.sdkKey}.json`
                     const interceptor = scope
                         .get(configRequestUrl)
-    
+
                     interceptor.reply(404)
-    
+
                     await waitForRequest(
                         scope,
                         interceptor,
@@ -60,20 +60,20 @@ describe('allFeatures Tests - Local', () => {
                 })
 
                 it('should return empty object if client is uninitialized',  async () => {
-                    const featuresResponse = await testClient.callAllFeatures(variationOnUser, false)
+                    const featuresResponse = await testClient.callAllFeatures(variationOnUser)
                     const features = await featuresResponse.json()
                     expect(features).toMatchObject({})
                 })
 
                 it.failing('should throw exception if user is invalid',  async () => { // TODO fix in node sdk
-                    const featuresResponse = await testClient.callAllFeatures(invalidUser, false)
+                    const featuresResponse = await testClient.callAllFeatures(invalidUser)
                     const response = await featuresResponse.json()
                     expect(response.exception).toBe('Must have a user_id set on the user')
                 })
             })
 
             describe('initialized client', () => {
-                const testClient = new TestClient(name)
+                const testClient = new LocalTestClient(name)
 
                 beforeAll(async () => {
                     await testClient.createClient()
@@ -85,23 +85,23 @@ describe('allFeatures Tests - Local', () => {
                     await testClient.callOnClientInitialized()
                 })
 
-                it('should return all features for user without custom data',  async () => {    
-                    const featuresResponse = await testClient.callAllFeatures(noVariationUser, false)
+                it('should return all features for user without custom data',  async () => {
+                    const featuresResponse = await testClient.callAllFeatures(noVariationUser)
                     const features = (await featuresResponse.json()).data
                     expect(features).toMatchObject({
                         'schedule-feature': { ...expectedFeaturesVariationOn['schedule-feature'] }
-                    })                
+                    })
                 })
 
-                it('should return all features for user with custom data',  async () => {    
-                    const featuresResponse = await testClient.callAllFeatures(variationOnUser, false)
+                it('should return all features for user with custom data',  async () => {
+                    const featuresResponse = await testClient.callAllFeatures(variationOnUser)
                     const features = (await featuresResponse.json()).data
                     expect(features).toMatchObject(expectedFeaturesVariationOn)
 
                 })
 
-                it('should throw exception if user is invalid',  async () => {    
-                    const featuresResponse = await testClient.callAllFeatures(invalidUser, false)
+                it('should throw exception if user is invalid',  async () => {
+                    const featuresResponse = await testClient.callAllFeatures(invalidUser)
                     const response = await featuresResponse.json()
                     expect(response.exception).toBe('Must have a user_id set on the user')
                 })

--- a/harness/features/allVariables.local.test.ts
+++ b/harness/features/allVariables.local.test.ts
@@ -1,14 +1,11 @@
 import {
     getConnectionStringForProxy,
     forEachSDK,
-    createClient,
     describeIf,
-    callAllVariablesLocal,
     createUser,
     wait,
-    mockServerUrl
+    LocalTestClient
 } from '../helpers'
-import { v4 as uuidv4 } from 'uuid'
 import { Capabilities, SDKCapabilities } from '../types'
 import { config, variables } from '../mockData'
 import nock, { Interceptor } from 'nock'
@@ -22,20 +19,20 @@ describe('allVariables Tests - Local', () => {
 
     forEachSDK((name: string) => {
         const capabilities: string[] = SDKCapabilities[name]
-        const clientId = uuidv4()
-        const sdkKey = `server_${clientId}`
         let url: string
+
+        let client = new LocalTestClient(name)
 
         beforeAll(async () => {
             configInterceptor = scope
-                .get(`/client/${clientId}/config/v1/server/${sdkKey}.json`)
+                .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
             configInterceptor
                 .reply(200, config)
                 .persist()
 
             url = getConnectionStringForProxy(name)
-            await createClient(url, clientId, sdkKey, { baseURLOverride: `${mockServerUrl}/client/${clientId}` })
-            await wait(500)
+            await client.createClient()
+            await client.callOnClientInitialized()
         })
 
         afterAll(() => {
@@ -44,15 +41,14 @@ describe('allVariables Tests - Local', () => {
 
         describeIf(capabilities.includes(Capabilities.local))(name, () => {
             it('should return an empty object if client is not initialized', async () => {
-                const clientId = uuidv4()
-                const sdkKey = `server_${clientId}`
+                const client = new LocalTestClient(name)
+
                 scope
-                    .get(`/client/${clientId}/config/v1/server/${sdkKey}.json`)
+                    .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
                     .delay(2000)
                     .reply(200, config)
 
-                await createClient(url, clientId, sdkKey, { baseURLOverride: `${mockServerUrl}/client/${clientId}` })
-                await wait(500)
+                await client.createClient()
 
                 const user = {
                     user_id: 'test_user',
@@ -62,7 +58,7 @@ describe('allVariables Tests - Local', () => {
                 }
                 const userResponse = await createUser(url, user)
                 const userLocation = userResponse.headers.get('Location')
-                const response = await callAllVariablesLocal(clientId, url, userLocation)
+                const response = await client.callAllVariables(userLocation)
                 const { data: variablesMap } = await response.json()
 
                 expect(variablesMap).toMatchObject({})
@@ -74,7 +70,7 @@ describe('allVariables Tests - Local', () => {
                 }
                 const userResponse = await createUser(url, user)
                 const userLocation = userResponse.headers.get('Location')
-                const response = await callAllVariablesLocal(clientId, url, userLocation)
+                const response = await client.callAllVariables(userLocation)
                 const { exception } = await response.json()
 
                 expect(exception).toEqual('Must have a user_id set on the user')
@@ -89,7 +85,7 @@ describe('allVariables Tests - Local', () => {
                 }
                 const userResponse = await createUser(url, user)
                 const userLocation = userResponse.headers.get('Location')
-                const response = await callAllVariablesLocal(clientId, url, userLocation)
+                const response = await client.callAllVariables(userLocation)
                 const { data: variablesMap, entityType } = await response.json()
 
                 expect(entityType).toEqual('Object')

--- a/harness/features/initialize.cloud.test.ts
+++ b/harness/features/initialize.cloud.test.ts
@@ -2,7 +2,7 @@ import {
     getConnectionStringForProxy,
     forEachSDK,
     describeIf,
-    TestClient
+    CloudTestClient
 } from '../helpers'
 import { Capabilities, SDKCapabilities } from '../types'
 
@@ -12,10 +12,6 @@ describe('Client Initialize Tests - Cloud', () => {
     forEachSDK((name) => {
         let url: string
         const capabilities: string[] = SDKCapabilities[name]
-
-        const clientOptions = {
-            enableCloudBucketing: true,
-        }
 
         beforeAll(async () => {
             url = getConnectionStringForProxy(name)
@@ -29,8 +25,8 @@ describe('Client Initialize Tests - Cloud', () => {
         describeIf(capabilities.includes(Capabilities.cloud))(name, () => {
 
             it('should throw an exception and return no location if invalid SDK token is sent', async () => {
-                const client = new TestClient(name)
-                const response = await client.createClient(clientOptions, 'invalidKey')
+                const client = new CloudTestClient(name)
+                const response = await client.createClient({}, 'invalidKey')
                 const body = await response.json()
                 expect(body.exception).toBe('Invalid environment key provided. Please call initialize with a valid server environment key')
                 const createdClientId = response.headers.get('location')
@@ -38,8 +34,8 @@ describe('Client Initialize Tests - Cloud', () => {
             })
 
             it('should throw an exception and return no location if no SDK token is sent', async () => {
-                const client = new TestClient(name)
-                const response = await client.createClient(clientOptions, null)
+                const client = new CloudTestClient(name)
+                const response = await client.createClient({}, null)
                 const body = await response.json()
                 expect(body.exception).toBe('Missing environment key! Call initialize with a valid environment key')
                 const createdClientId = response.headers.get('location')
@@ -47,9 +43,8 @@ describe('Client Initialize Tests - Cloud', () => {
             })
 
             it('should return client object location if SDK token is correct', async () => {
-                const client = new TestClient(name)
-                const response = await client.createClient({ ...clientOptions })
-
+                const client = new CloudTestClient(name)
+                const response = await client.createClient({})
                 const body = await response.json()
                 expect(body.message).toBe('success')
             })

--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -5,7 +5,7 @@ import {
     createUser,
     forEachVariableType,
     variablesForTypes,
-    TestClient
+    CloudTestClient
 } from '../helpers'
 import { Capabilities, SDKCapabilities } from '../types'
 import { getServerScope } from '../nock'
@@ -18,7 +18,7 @@ describe('Variable Tests - Cloud', () => {
     forEachSDK((name) => {
         const capabilities: string[] = SDKCapabilities[name]
 
-        let testClient = new TestClient(name)
+        let testClient = new CloudTestClient(name)
 
         let url = getConnectionStringForProxy(name)
 
@@ -40,7 +40,7 @@ describe('Variable Tests - Cloud', () => {
                 const userId = response.headers.get('location')
                 expect(userId.includes('user/')).toBeTruthy()
 
-                const variableResponse = await testClient.callVariable(userId, true, 'var_key', 'default_value')
+                const variableResponse = await testClient.callVariable(userId, 'var_key', 'default_value')
                 const error = await variableResponse.json()
                 expect(error.asyncError).toBe('Must have a user_id set on the user')
             })
@@ -55,7 +55,7 @@ describe('Variable Tests - Cloud', () => {
                 const userId = response.headers.get('location')
                 expect(userId.includes('user/')).toBeTruthy()
 
-                const variableResponse = await testClient.callVariable(userId, true, undefined, 'default_value')
+                const variableResponse = await testClient.callVariable(userId, undefined, 'default_value')
                 const error = await variableResponse.json()
                 expect(error.asyncError).toBe('Missing parameter: key')
             })
@@ -70,7 +70,7 @@ describe('Variable Tests - Cloud', () => {
                 const userId = response.headers.get('location')
                 expect(userId.includes('user/')).toBeTruthy()
 
-                const variableResponse = await testClient.callVariable(userId, true, 'var_key', undefined)
+                const variableResponse = await testClient.callVariable(userId, 'var_key', undefined)
                 const error = await variableResponse.json()
                 expect(error.asyncError).toBe('Missing parameter: defaultValue')
             })
@@ -93,7 +93,7 @@ describe('Variable Tests - Cloud', () => {
                         defaultValue: 'default_value',
                         isDefaulted: false
                     })
-                const variableResponse = await testClient.callVariable(userId, true, 'var_key', 'default_value')
+                const variableResponse = await testClient.callVariable(userId, 'var_key', 'default_value')
                 await variableResponse.json()
             })
 
@@ -102,7 +102,7 @@ describe('Variable Tests - Cloud', () => {
                 await response.json()
                 const userId = response.headers.get('location')
 
-                const testClient = new TestClient(name)
+                const testClient = new CloudTestClient(name)
 
                 await testClient.createClient({
                     enableCloudBucketing: true,
@@ -122,7 +122,7 @@ describe('Variable Tests - Cloud', () => {
                         defaultValue: 'default_value',
                         isDefaulted: false
                     })
-                const variableResponse = await testClient.callVariable(userId, true, 'var_key', 'default_value')
+                const variableResponse = await testClient.callVariable(userId, 'var_key', 'default_value')
                 await variableResponse.json()
 
             })
@@ -146,7 +146,6 @@ describe('Variable Tests - Cloud', () => {
 
                 const variableResponse = await testClient.callVariable(
                     userId,
-                    true,
                     'var_key',
                     variablesForTypes['string'].defaultValue
                 )
@@ -177,7 +176,6 @@ describe('Variable Tests - Cloud', () => {
 
                     const variableResponse = await testClient.callVariable(
                         userId,
-                        true,
                         'var_key',
                         variablesForTypes[type].defaultValue
                     )
@@ -208,7 +206,6 @@ describe('Variable Tests - Cloud', () => {
 
                     const variableResponse = await testClient.callVariable(
                         userId,
-                        true,
                         'var_key',
                         variablesForTypes[type].defaultValue
                     )
@@ -241,7 +238,6 @@ describe('Variable Tests - Cloud', () => {
 
                     const variableResponse = await testClient.callVariable(
                         userId,
-                        true,
                         'var_key',
                         variablesForTypes[type].defaultValue
                     )

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
     transform: {
         '^.+\\.tsx?$': ['ts-jest', {}]
     },
-    testEnvironment: './jest-environment.ts',
+    testEnvironment: './jest-environment.ts'
 };

--- a/proxies/nodejs/entityTypes.ts
+++ b/proxies/nodejs/entityTypes.ts
@@ -5,6 +5,7 @@ export enum EntityTypes {
     variable = 'Variable',
     feature = 'Feature',
     object = 'Object',
+    client = 'Client'
 }
 
 export type DataStore = {
@@ -21,6 +22,8 @@ export const getEntityFromType = (value: string): string => {
             return EntityTypes.variable
         case 'DVCFeature':
             return EntityTypes.feature
+        case 'DVCClient':
+            return EntityTypes.client
         default:
             return EntityTypes.object
     }

--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -1,6 +1,6 @@
 import { DVCClient, DVCUser, DVCVariable } from '@devcycle/nodejs-server-sdk'
 import Koa from 'koa'
-import { getEntityFromType, DataStore } from '../entityTypes'
+import { getEntityFromType, DataStore, EntityTypes } from '../entityTypes'
 import { dataStore } from '../app'
 
 //HTTP request comes in as string
@@ -83,8 +83,8 @@ export const handleLocation = async (
             ctx.set('Location', `command/${command}/${commandId}`)
             ctx.body = {
                 entityType: entityType,
-                data: result,
-                logs: [], // TODO add logs 
+                data: entityType === EntityTypes.client ? {} : result,
+                logs: [], // TODO add logs
             }
         }
     } catch (error) {

--- a/proxies/nodejs/package.json
+++ b/proxies/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@devcycle/nodejs-server-sdk": "^1.4.25",
+    "@devcycle/nodejs-server-sdk": "^1.4.26",
     "@types/koa": "^2.13.5",
     "@types/koa-bodyparser": "^4.3.10",
     "@types/koa-router": "^7.4.4",

--- a/proxies/nodejs/yarn.lock
+++ b/proxies/nodejs/yarn.lock
@@ -16,18 +16,18 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@devcycle/bucketing-assembly-script@^1.1.18":
-  version "1.1.18"
-  resolved "https://registry.yarnpkg.com/@devcycle/bucketing-assembly-script/-/bucketing-assembly-script-1.1.18.tgz#03dcf3f4c4aa80532b81e235908a89cc09ef38fb"
-  integrity sha512-KF8HKH5VTzW6KhX5XksgNRSx/XBRPlr/5mUwjsTfICFCE9Q9mbyrN2myvpyVUSxDsw5JO4kcT3tq/0x/r2ULTg==
+"@devcycle/bucketing-assembly-script@^1.1.22":
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/@devcycle/bucketing-assembly-script/-/bucketing-assembly-script-1.1.22.tgz#5d1dab63fbe2320911f6d64a6bd0e31e77839f18"
+  integrity sha512-FnQ2fIPRDb68rDK0pqvHT02OE96cnSbBAedgBrIsYVHampzvw0fCOuSiv3o97zk9FJg7cdfJzZJxMuqRzDBl3g==
 
-"@devcycle/nodejs-server-sdk@^1.4.19":
-  version "1.4.19"
-  resolved "https://registry.yarnpkg.com/@devcycle/nodejs-server-sdk/-/nodejs-server-sdk-1.4.19.tgz#2b3388e0c34ccf236fda1bda747ed53b33a7304a"
-  integrity sha512-f5D7BF7avdYyNLEbkTlAWYSwFGvdxvSC90dpBQU5rXZdvcIlbdn27LXsey4IwR3PEoYSxt0TrfZpuWkOG6yTKw==
+"@devcycle/nodejs-server-sdk@^1.4.26":
+  version "1.4.26"
+  resolved "https://registry.yarnpkg.com/@devcycle/nodejs-server-sdk/-/nodejs-server-sdk-1.4.26.tgz#eea15a3af589bdcdaeffc5e17b48b3b6868f31cf"
+  integrity sha512-GibqupdUiTAn8nMQosc6usiuCTgG1pYNYeV07K49Do0G2czRjl8gDWl3QjLExyWEFANQ6ht6xVs9cQ6sL/gpwg==
   dependencies:
-    "@devcycle/bucketing-assembly-script" "^1.1.18"
-    "@devcycle/types" "1.0.50"
+    "@devcycle/bucketing-assembly-script" "^1.1.22"
+    "@devcycle/types" "1.0.52"
     "@nestjs/class-validator" "^0.13.4"
     as-uuid "^0.0.4"
     axios "^0.27.2"
@@ -40,10 +40,10 @@
     reflect-metadata "^0.1.13"
     uuid "^8.3.2"
 
-"@devcycle/types@1.0.50":
-  version "1.0.50"
-  resolved "https://registry.yarnpkg.com/@devcycle/types/-/types-1.0.50.tgz#c341806d585dead4525d1f2f551ed67e22345906"
-  integrity sha512-6bLMM+ZLwk7wmYVpZITTtOIBQARGMF2gxQVIqMr5qIALkF34mObCTgUtV2P1+lelIuFPs/fXUXApuAXTyLi95w==
+"@devcycle/types@1.0.52":
+  version "1.0.52"
+  resolved "https://registry.yarnpkg.com/@devcycle/types/-/types-1.0.52.tgz#a37183787617e54d4e61cd96bd0682ae3cbc39d5"
+  integrity sha512-eGzCYBi9eSBr+xSpoXYJUsOcNN+Lhhq6aWDqHXJ3ZjHVSRi0BjMld/4sP1Odf9Oe9OYj57OfteIQ6OPq0vJYuw==
   dependencies:
     "@nestjs/class-validator" "^0.13.4"
     "@types/validator" "13.7.6"


### PR DESCRIPTION
Separate the cloud and local clients into two separate test helpers

Both helpers pass the appropriate option to the proxy when calling `createClient` to make the right kind of client

The call methods (callVariable, callAllVariables etc.) correctly set the `isAsync` property to true or false depending on the client.

Also fixed some sources of errors happening on the proxy server:
- initialize tests now respond to CDN request with a valid config
- event API mocking now always returns 201 instead of 200

The "wait for initialize" method will now make sure the request was successful and that the SDK did not throw an error. The same will happen for track unless you specify that you're expecting it to fail.