### PR TITLE
DVC-5572 nock reset scopes

### DIFF
--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -96,6 +96,7 @@ describe('Variable Tests - Local', () => {
                 afterAll(async () => {
                     await testClient.close()
                 })
+
                 it('should throw exception if user is invalid',  async () => {
                     const variableResponse =
                         await testClient.callVariable(invalidUser.location, 'string-var', 'string default', true)
@@ -121,6 +122,8 @@ describe('Variable Tests - Local', () => {
                             defaultValue
                         )
                         const variable = await variableResponse.json()
+                        await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
+
                         expect(variable).toEqual(expect.objectContaining({
                             entityType: 'Variable',
                             data: expect.objectContaining({
@@ -130,7 +133,6 @@ describe('Variable Tests - Local', () => {
                             })
                         }))
 
-                        await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
                         expectEventBody(eventBody, key, 'aggVariableEvaluated')
                     })
 
@@ -150,10 +152,10 @@ describe('Variable Tests - Local', () => {
                                 wrongTypeDefault
                             )
                         const variable = await variableResponse.json()
+                        await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
 
                         expectDefaultValue(key, variable, wrongTypeDefault,
                             wrongTypeDefault === '1' ? VariableType.string : VariableType.number)
-                        await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
                         expectEventBody(eventBody, key, 'aggVariableEvaluated')
                     })
 
@@ -170,9 +172,9 @@ describe('Variable Tests - Local', () => {
                             defaultValue
                         )
                         const variable = await variableResponse.json()
+                        await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
 
                         expectDefaultValue(key, variable, defaultValue, variableType)
-                        await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
                         expectEventBody(eventBody, key, 'aggVariableDefaulted')
                     })
 
@@ -190,9 +192,9 @@ describe('Variable Tests - Local', () => {
                             defaultValue
                         )
                         const variable = await variableResponse.json()
+                        await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
 
                         expectDefaultValue('nonexistent', variable, defaultValue, variableType)
-                        await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
                         expectEventBody(eventBody, 'nonexistent', 'aggVariableDefaulted')
                     })
 
@@ -278,7 +280,7 @@ describe('Variable Tests - Local', () => {
                         expectDefaultValue(key, variable, defaultValue, variableType)
                     })
 
-                    it.failing('should throw exception if user is invalid',  async () => {
+                    it('should throw exception if user is invalid',  async () => {
                         const variableResponse =
                             await testClient.callVariable(invalidUser.location, key, defaultValue)
                         const variable = await variableResponse.json()

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -282,7 +282,7 @@ describe('Variable Tests - Local', () => {
 
                     it('should throw exception if user is invalid',  async () => {
                         const variableResponse =
-                            await testClient.callVariable(invalidUser.location, key, defaultValue)
+                            await testClient.callVariable(invalidUser.location, key, defaultValue, true)
                         const variable = await variableResponse.json()
 
                         expect(variable.exception).toBe('Must have a user_id set on the user')

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -1,7 +1,7 @@
 import { Interceptor, Scope } from 'nock'
 import { Sdks } from './types'
 import nock from 'nock'
-import { getServerScope } from './nock'
+import { getServerScope, resetServerScope } from './nock'
 import { v4 as uuidv4 } from 'uuid'
 
 const oldFetch = fetch
@@ -50,6 +50,7 @@ export const forEachSDK = (tests) => {
                 const pendingMocks = scope.pendingMocks()
                 throw new Error('Unsatisfied nock scopes: ' + pendingMocks)
             }
+            await resetServerScope()
             await global.assertNoUnmatchedRequests()
         })
         afterAll(() => {

--- a/harness/nock.ts
+++ b/harness/nock.ts
@@ -1,4 +1,34 @@
-import nock from 'nock'
+import nock, { Interceptor, Scope } from 'nock'
 
 const scope = nock('https://nock.com')
-export const getServerScope = () => scope
+
+type ScopeArgs = Parameters<nock.Scope['post']>
+
+let interceptors: nock.Interceptor[] = []
+
+/**
+ * implement a proxy wrapper for nock scope
+ */
+const scopeProxy = new Proxy(scope, {
+    get: function(target, prop: keyof Scope, receiver) {
+        const result = Reflect.get(target, prop, receiver);
+        if (prop === "get" || prop === "post" || prop === "put" || prop === "head" || prop === "patch") {
+            const original = result as Scope['get']
+            return (...args: ScopeArgs) => {
+                const interceptor = original.call(target, ...args)
+                interceptors.push(interceptor)
+                return interceptor
+            }
+        } else {
+            return result
+        }
+    },
+})
+export const getServerScope = (): Scope => scopeProxy
+
+export const resetServerScope = () => {
+    for (let i of interceptors) {
+        nock.removeInterceptor(i)
+    }
+    interceptors = []
+}


### PR DESCRIPTION
Reset nock scopes between test cases so that an unmatched interceptor won't continue to exist and continue to not be matched on all following test cases after it's missed the first time.

This should make it easier to tell which test case actually failed and which ones are just failing due to a cascade of unsatisfied mocks.

Also reorganize the await request statements in the variable local tests so that the assertion on the response body does not prevent it from waiting for the event request to come in. This prevents further tests from failing due to not waiting for the event request from a test case whose response body was wrong (but where the SDK sends an event regardless)