### PR TITLE
chore: change location endpoint usage

### DIFF
--- a/harness/features/allFeatures.cloud.test.ts
+++ b/harness/features/allFeatures.cloud.test.ts
@@ -16,7 +16,6 @@ const scope = getServerScope()
 describe('allFeatures Tests - Cloud', () => {
     forEachSDK((name) => {
         const testClient = new CloudTestClient(name)
-        const capabilities: string[] = SDKCapabilities[name]
 
         beforeAll(async () => {
             await testClient.createClient({

--- a/harness/features/allFeatures.cloud.test.ts
+++ b/harness/features/allFeatures.cloud.test.ts
@@ -16,20 +16,12 @@ const scope = getServerScope()
 describe('allFeatures Tests - Cloud', () => {
     forEachSDK((name) => {
         const testClient = new CloudTestClient(name)
-
-        let url: string
-
-        let variationOnUser: string
+        const capabilities: string[] = SDKCapabilities[name]
 
         beforeAll(async () => {
-            url = getConnectionStringForProxy(name)
             await testClient.createClient({
                 enableCloudBucketing: true,
             })
-
-            variationOnUser = (
-                await createUser(url, { user_id: 'user1', customData: { 'should-bucket': true } })
-            ).headers.get('location')
         })
 
         describeCapability(name, Capabilities.cloud)(name, () => {
@@ -42,7 +34,10 @@ describe('allFeatures Tests - Cloud', () => {
                         return !queryObj.enableEdgeDB
                     })
                     .reply(200, expectedFeaturesVariationOn)
-                const featuresResponse = await testClient.callAllFeatures(variationOnUser)
+                const featuresResponse = await testClient.callAllFeatures({ 
+                    user_id: 'user1', 
+                    customData: { 'should-bucket': true } 
+                })
 
                 const features = await featuresResponse.json()
                 expect(features).toMatchObject({
@@ -68,7 +63,10 @@ describe('allFeatures Tests - Cloud', () => {
                     })
                     .reply(200, expectedFeaturesVariationOn)
 
-                const featuresResponse = await edgeDBTestClient.callAllFeatures(variationOnUser)
+                const featuresResponse = await edgeDBTestClient.callAllFeatures({ 
+                    user_id: 'user1', 
+                    customData: { 'should-bucket': true } 
+                })
                 const features = await featuresResponse.json()
                 expect(features).toMatchObject({
                     entityType: 'Object',

--- a/harness/features/allFeatures.local.test.ts
+++ b/harness/features/allFeatures.local.test.ts
@@ -1,12 +1,9 @@
 import {
-    getConnectionStringForProxy,
     forEachSDK,
-    describeIf,
-    createUser,
     LocalTestClient,
     waitForRequest, describeCapability
 } from '../helpers'
-import { Capabilities, SDKCapabilities } from '../types'
+import { Capabilities } from '../types'
 import { getServerScope } from '../nock'
 import { config, expectedFeaturesVariationOn } from '../mockData/config'
 
@@ -16,9 +13,7 @@ const scope = getServerScope()
 
 describe('allFeatures Tests - Local', () => {
     forEachSDK((name) => {
-        const capabilities: string[] = SDKCapabilities[name]
-
-        describeIf(capabilities.includes(Capabilities.local))(name, () => {
+        describeCapability(name, Capabilities.local)(name, () => {
             describe('uninitialized client', () => {
                 const testClient = new LocalTestClient(name)
 

--- a/harness/features/allFeatures.local.test.ts
+++ b/harness/features/allFeatures.local.test.ts
@@ -16,24 +16,9 @@ const scope = getServerScope()
 
 describe('allFeatures Tests - Local', () => {
     forEachSDK((name) => {
-        let url: string
+        const capabilities: string[] = SDKCapabilities[name]
 
-        let variationOnUser: string
-        let noVariationUser: string
-
-        beforeAll(async () => {
-            url = getConnectionStringForProxy(name)
-
-            variationOnUser = (
-                await createUser(url, { user_id: 'user1', customData: { 'should-bucket': true } })
-            ).headers.get('location')
-
-            noVariationUser = (
-                await createUser(url, { user_id: 'user3' })
-            ).headers.get('location')
-        })
-
-        describeCapability(name, Capabilities.local)(name, () => {
+        describeIf(capabilities.includes(Capabilities.local))(name, () => {
             describe('uninitialized client', () => {
                 const testClient = new LocalTestClient(name)
 
@@ -58,7 +43,10 @@ describe('allFeatures Tests - Local', () => {
                 })
 
                 it('should return empty object if client is uninitialized',  async () => {
-                    const featuresResponse = await testClient.callAllFeatures(variationOnUser)
+                    const featuresResponse = await testClient.callAllFeatures({ 
+                        user_id: 'user1', 
+                        customData: { 'should-bucket': true }
+                    })
                     const features = await featuresResponse.json()
                     expect(features).toMatchObject({})
                 })
@@ -80,7 +68,7 @@ describe('allFeatures Tests - Local', () => {
                 })
 
                 it('should return all features for user without custom data',  async () => {
-                    const featuresResponse = await testClient.callAllFeatures(noVariationUser)
+                    const featuresResponse = await testClient.callAllFeatures({ user_id: 'user3' })
                     const features = (await featuresResponse.json()).data
                     expect(features).toMatchObject({
                         'schedule-feature': { ...expectedFeaturesVariationOn['schedule-feature'] }
@@ -88,7 +76,10 @@ describe('allFeatures Tests - Local', () => {
                 })
 
                 it('should return all features for user with custom data',  async () => {
-                    const featuresResponse = await testClient.callAllFeatures(variationOnUser)
+                    const featuresResponse = await testClient.callAllFeatures({ 
+                        user_id: 'user1', 
+                        customData: { 'should-bucket': true } 
+                    })
                     const features = (await featuresResponse.json()).data
                     expect(features).toMatchObject(expectedFeaturesVariationOn)
 

--- a/harness/features/allVariables.cloud.test.ts
+++ b/harness/features/allVariables.cloud.test.ts
@@ -17,7 +17,7 @@ describe('allVariables Tests - Cloud', () => {
     forEachSDK((name: string) => {
         let url: string
 
-        let client = new CloudTestClient(name)
+        const client = new CloudTestClient(name)
 
         beforeAll(async () => {
             url = getConnectionStringForProxy(name)
@@ -30,13 +30,10 @@ describe('allVariables Tests - Cloud', () => {
                     .post(`/client/${client.clientId}/v1/variables`)
                     .reply(404)
 
-                const user = {
+                const response = await client.callAllVariables({
                     user_id: 'test_user',
                     email: 'user@gmail.com'
-                }
-                const userResponse = await createUser(url, user)
-                const userLocation = userResponse.headers.get('Location')
-                const response = await client.callAllVariables(userLocation)
+                })
                 const { data: variablesMap } = await response.json()
 
                 expect(variablesMap).toMatchObject({})
@@ -46,14 +43,10 @@ describe('allVariables Tests - Cloud', () => {
                 scope
                     .post(`/client/${client.clientId}/v1/variables`)
                     .reply(200, variables)
-
-                const user = {
+                const response = await client.callAllVariables({
                     user_id: 'test_user',
                     email: 'user@gmail.com',
-                }
-                const userResponse = await createUser(url, user)
-                const userLocation = userResponse.headers.get('Location')
-                const response = await client.callAllVariables(userLocation)
+                })
                 const { data: variablesMap, entityType } = await response.json()
 
                 expect(entityType).toEqual('Object')
@@ -68,13 +61,10 @@ describe('allVariables Tests - Cloud', () => {
                     })
                     .reply(200, variables)
 
-                const user = {
+                await client.callAllVariables({
                     user_id: 'test_user',
                     email: 'user@gmail.com',
-                }
-                const userResponse = await createUser(url, user)
-                const userLocation = userResponse.headers.get('Location')
-                await client.callAllVariables(userLocation)
+                })
             })
 
             it('should make a request to the variables endpoint with edgeDB param to true', async () => {
@@ -90,13 +80,10 @@ describe('allVariables Tests - Cloud', () => {
                     enableEdgeDB: true
                 })
 
-                const user = {
+                await client.callAllVariables({
                     user_id: 'test_user',
                     email: 'user@gmail.com',
-                }
-                const userResponse = await createUser(url, user)
-                const userLocation = userResponse.headers.get('Location')
-                await client.callAllVariables(userLocation)
+                })
             })
         })
     })

--- a/harness/features/allVariables.local.test.ts
+++ b/harness/features/allVariables.local.test.ts
@@ -18,7 +18,7 @@ describe('allVariables Tests - Local', () => {
     forEachSDK((name: string) => {
         let url: string
 
-        let client = new LocalTestClient(name)
+        const client = new LocalTestClient(name)
 
         beforeAll(async () => {
             configInterceptor = scope
@@ -46,14 +46,11 @@ describe('allVariables Tests - Local', () => {
 
                 await delayClient.createClient()
 
-                const user = {
+                const response = await delayClient.callAllVariables({
                     user_id: 'test_user',
                     email: 'user@gmail.com',
                     customData: { 'should-bucket': true }
-                }
-                const userResponse = await createUser(url, user)
-                const userLocation = userResponse.headers.get('Location')
-                const response = await delayClient.callAllVariables(userLocation)
+                })
                 const { data: variablesMap } = await response.json()
 
                 expect(variablesMap).toMatchObject({})
@@ -61,14 +58,11 @@ describe('allVariables Tests - Local', () => {
             })
 
             it('should return a variable map for a bucketed user', async () => {
-                const user = {
+                const response = await client.callAllVariables({
                     user_id: 'test_user',
                     email: 'user@gmail.com',
                     customData: { 'should-bucket': true }
-                }
-                const userResponse = await createUser(url, user)
-                const userLocation = userResponse.headers.get('Location')
-                const response = await client.callAllVariables(userLocation)
+                })
                 const { data: variablesMap, entityType } = await response.json()
 
                 expect(entityType).toEqual('Object')

--- a/harness/features/track.cloud.test.ts
+++ b/harness/features/track.cloud.test.ts
@@ -32,11 +32,7 @@ describe('Track Tests - Cloud', () => {
 
         describeCapability(name, Capabilities.cloud)(name, () => {
             it('should complain if event type not set', async () => {
-                const response = await createUser(url, { user_id: validUserId })
-                await response.json()
-                const userId = response.headers.get('location')
-
-                const trackResponse = await client.callTrack(userId, { target: 1 }, true)
+                const trackResponse = await client.callTrack({ user_id: validUserId }, { target: 1 }, true)
                 const res = await trackResponse.json()
                 expect(res.exception).toBe('Invalid Event')
             })
@@ -47,10 +43,6 @@ describe('Track Tests - Cloud', () => {
                 const variableId = 'string-var'
                 const value = 1
 
-                const response = await createUser(url, { user_id: validUserId })
-                await response.json()
-                const userId = response.headers.get('location')
-
                 const interceptor = scope
                     .post(`/client/${client.clientId}/v1/track`)
 
@@ -60,7 +52,7 @@ describe('Track Tests - Cloud', () => {
                     return [201, { success: true }]
                 })
 
-                await client.callTrack(userId,
+                await client.callTrack({ user_id: validUserId },
                     { type: eventType, target: variableId, value })
 
                 await waitForRequest(scope, interceptor, 550, 'Event callback timed out')
@@ -75,10 +67,6 @@ describe('Track Tests - Cloud', () => {
                 const variableId = 'json-var'
                 const value = 1
 
-                const response = await createUser(url, { user_id: validUserId })
-                await response.json()
-                const userId = response.headers.get('location')
-
                 scope
                     .post(`/client/${client.clientId}/v1/track`)
                     .matchHeader('Content-Type', 'application/json')
@@ -92,7 +80,7 @@ describe('Track Tests - Cloud', () => {
                     return [201, { success: true }]
                 })
 
-                const trackResponse = await client.callTrack(userId,
+                const trackResponse = await client.callTrack({ user_id: validUserId },
                     { type: eventType, target: variableId, value })
 
                 await trackResponse.json()

--- a/harness/features/track.local.test.ts
+++ b/harness/features/track.local.test.ts
@@ -2,7 +2,6 @@ import {
     getConnectionStringForProxy,
     forEachSDK,
     describeIf,
-    createUser,
     wait,
     waitForRequest,
     LocalTestClient, describeCapability
@@ -47,11 +46,7 @@ describe('Track Tests - Local', () => {
 
             describe('Expect no events sent', () => {
                 it('should not send an event if the event type not set', async () => {
-                    const response = await createUser(url, { user_id: validUserId })
-                    await response.json()
-                    const userId = response.headers.get('location')
-
-                    const trackResponse = await client.callTrack(userId, {}, true)
+                    const trackResponse = await client.callTrack({ user_id: validUserId }, {}, true)
 
                     const res = await trackResponse.json()
                     expect(res.exception).toBe('Missing parameter: type') // works for GH actions sometimes
@@ -69,17 +64,13 @@ describe('Track Tests - Local', () => {
                     const variableId = 'string-var'
                     const value = 1
 
-                    const response = await createUser(url, { user_id: validUserId })
-                    await response.json()
-                    const userId = response.headers.get('location')
-
                     const interceptor = scope.post(`/client/${client.clientId}/v1/events/batch`)
                     interceptor.reply((uri, body) => {
                         eventBody = body
                         return [201]
                     })
 
-                    const trackResponse = await client.callTrack(userId,
+                    const trackResponse = await client.callTrack({ user_id: validUserId },
                         { type: eventType, target: 'string-var', value: value })
 
                     await trackResponse.json()
@@ -119,20 +110,15 @@ describe('Track Tests - Local', () => {
                     const variableId2 = 'json-var'
                     const value2 = 3
 
-                    const response = await createUser(url, { user_id: validUserId })
-                    await response.json()
-                    const userId = response.headers.get('location')
-
-
                     const interceptor = scope.post(`/client/${client.clientId}/v1/events/batch`)
                     interceptor.reply((uri, body) => {
                         eventBody = body
                         return [201]
                     })
 
-                    await client.callTrack(userId,
+                    await client.callTrack({ user_id: validUserId },
                         { type: eventType, target: variableId, value: value })
-                    await client.callTrack(userId,
+                    await client.callTrack({ user_id: validUserId },
                         { type: eventType2, target: variableId2, value: value2 })
 
                     await waitForRequest(scope, interceptor, eventFlushIntervalMS * 2, 'Event callback timed out')
@@ -166,7 +152,7 @@ describe('Track Tests - Local', () => {
                     })
                 })
 
-                it('should retry events API call to track 2 events, and check interval of events is in specified window',
+                it('should retry events API call to track 2 events and check interval of events is in specified window',
                     async () => {
                         let eventBody = {}
                         const timestamps = []
@@ -179,10 +165,6 @@ describe('Track Tests - Local', () => {
                         const eventType2 = 'textChanged'
                         const variableId2 = 'json-var'
                         const value2 = 3
-
-                        const response = await createUser(url, { user_id: validUserId })
-                        await response.json()
-                        const userId = response.headers.get('location')
 
                         let startDate = Date.now()
                         scope
@@ -202,9 +184,9 @@ describe('Track Tests - Local', () => {
                             return [201]
                         })
 
-                        await client.callTrack(userId,
+                        await client.callTrack({ user_id: validUserId },
                             { type: eventType, target: variableId, value: value })
-                        await client.callTrack(userId,
+                        await client.callTrack({ user_id: validUserId },
                             { type: eventType2, target: variableId2, value: value2 })
 
                         await waitForRequest(scope, interceptor, eventFlushIntervalMS * 5, 'Event callback timed out')

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -1,9 +1,8 @@
 import {
-    createUser, describeCapability,
-    describeIf,
+    describeCapability,
+    
     forEachSDK,
     forEachVariableType,
-    getConnectionStringForProxy,
     LocalTestClient,
     waitForRequest
 } from '../helpers'
@@ -48,25 +47,7 @@ const expectedVariablesByType = {
 
 describe('Variable Tests - Local', () => {
     forEachSDK((name) => {
-        const variationOnUser = { location: '', user_id: 'user1' }
-        const noVariationUser = { location: '', user_id: 'user3' }
-
         describeCapability(name, Capabilities.local)(name, () => {
-            let url: string
-
-            beforeAll(async () => {
-                url = getConnectionStringForProxy(name)
-
-                // create users
-                variationOnUser.location = (
-                    await createUser(url, { user_id: variationOnUser.user_id, customData: { 'should-bucket': true } })
-                ).headers.get('location')
-
-                noVariationUser.location = (
-                    await createUser(url, { user_id: noVariationUser.user_id })
-                ).headers.get('location')
-            })
-
             const testClient = new LocalTestClient(name)
             let eventsUrl: string
 
@@ -102,7 +83,7 @@ describe('Variable Tests - Local', () => {
                         })
 
                         const variableResponse = await testClient.callVariable(
-                            variationOnUser.location,
+                            { user_id: 'user1', customData: { 'should-bucket': true } },
                             key,
                             defaultValue
                         )
@@ -132,7 +113,7 @@ describe('Variable Tests - Local', () => {
                         const wrongTypeDefault = type === 'number' ? '1' : 1
                         const variableResponse =
                             await testClient.callVariable(
-                                variationOnUser.location,
+                                { user_id: 'user1', customData: { 'should-bucket': true } },
                                 key,
                                 wrongTypeDefault
                             )
@@ -152,7 +133,7 @@ describe('Variable Tests - Local', () => {
                             return [201]
                         })
                         const variableResponse = await testClient.callVariable(
-                            noVariationUser.location,
+                            { user_id: 'user3' },
                             key,
                             defaultValue
                         )
@@ -172,7 +153,7 @@ describe('Variable Tests - Local', () => {
                         })
 
                         const variableResponse = await testClient.callVariable(
-                            variationOnUser.location,
+                            { user_id: 'user1', customData: { 'should-bucket': true } },
                             'nonexistent',
                             defaultValue
                         )
@@ -192,12 +173,12 @@ describe('Variable Tests - Local', () => {
                         })
 
                         await testClient.callVariable(
-                            variationOnUser.location,
+                            { user_id: 'user1', customData: { 'should-bucket': true } },
                             'nonexistent',
                             defaultValue
                         )
                         await testClient.callVariable(
-                            variationOnUser.location,
+                            { user_id: 'user1', customData: { 'should-bucket': true } },
                             'nonexistent',
                             defaultValue
                         )
@@ -215,12 +196,12 @@ describe('Variable Tests - Local', () => {
                         })
 
                         await testClient.callVariable(
-                            variationOnUser.location,
+                            { user_id: 'user1', customData: { 'should-bucket': true } },
                             key,
                             defaultValue
                         )
                         await testClient.callVariable(
-                            variationOnUser.location,
+                            { user_id: 'user1', customData: { 'should-bucket': true } },
                             key,
                             defaultValue
                         )
@@ -259,7 +240,9 @@ describe('Variable Tests - Local', () => {
 
                     it('should return default value if client is uninitialized',  async () => {
                         const variableResponse = await testClient.callVariable(
-                            variationOnUser.location, key, defaultValue
+                            { user_id: 'user1', customData: { 'should-bucket': true } }, 
+                            key, 
+                            defaultValue
                         )
                         const variable = await variableResponse.json()
                         expectDefaultValue(key, variable, defaultValue, variableType)
@@ -304,7 +287,11 @@ describe('Variable Tests - Local', () => {
         }
     }
 
-    const expectDefaultValue = (key: string, variable: VariableResponse, defaultValue: ValueTypes, type: VariableType) => {
+    const expectDefaultValue = (
+        key: string, 
+        variable: VariableResponse, 
+        defaultValue: ValueTypes, 
+        type: VariableType) => {
         expect(variable).toEqual({
             entityType: 'Variable',
             data: {

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -192,10 +192,11 @@ export const wait = (ms: number) => {
     })
 }
 
-const callAllVariables = async (url: string, userLocation: string, isAsync: boolean) => {
+const callAllVariables = async (url: string, user: unknown, isAsync: boolean) => {
     return await sendCommand(url, {
         command: 'allVariables', 
-        params: [{ location: userLocation }], 
+        user,
+        params: [{ type: 'user' }], 
         isAsync
     })
 }
@@ -327,10 +328,10 @@ export class LocalTestClient extends BaseTestClient {
     }
 
     async callAllVariables(
-        userLocation: string,
+        user: unknown,
         shouldFail = false
     ) {
-        const result = await callAllVariables(this.getClientUrl(), userLocation, false)
+        const result = await callAllVariables(this.getClientUrl(), user, false)
 
         await checkFailed(result, shouldFail)
         return result
@@ -404,10 +405,10 @@ export class CloudTestClient extends BaseTestClient {
     }
 
     async callAllVariables(
-        userLocation: string,
+        user: unknown,
         shouldFail = false
     ) {
-        const result = await callAllVariables(this.getClientUrl(), userLocation, true)
+        const result = await callAllVariables(this.getClientUrl(), user, true)
         await checkFailed(result, shouldFail)
         return result
     }

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -142,16 +142,26 @@ export const createUser = async (url: string, user: object, shouldFail = false) 
     return result
 }
 
-export const sendCommand = async (url: string, command: string, params: unknown[], isAsync: boolean) => {
+type CommandBody = {
+    command: string,
+    isAsync?: boolean,
+    params: unknown[],
+    user?: Record<string, unknown>,
+    event?: Record<string, unknown>
+}
+
+export const sendCommand = async (url: string, body: CommandBody) => {
     return await fetch(url, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-            command,
-            isAsync,
-            params
+            command: body.command,
+            isAsync: body.isAsync,
+            params: body.params,
+            user: body.user,
+            event: body.event
         })
     })
 }
@@ -163,11 +173,15 @@ const callVariable = async (
     key?: string,
     defaultValue?: any,
 ) => {
-    return await sendCommand(url, 'variable', [
-        { location: `${userLocation}` },
-        { value: key },
-        { value: defaultValue }
-    ], isAsync)
+    return await sendCommand(url, {
+        command: 'variable', 
+        params: [
+            { location: `${userLocation}` },
+            { value: key },
+            { value: defaultValue }
+        ], 
+        isAsync
+    })
 }
 
 export const wait = (ms: number) => {
@@ -179,15 +193,27 @@ export const wait = (ms: number) => {
 }
 
 const callAllVariables = async (url: string, userLocation: string, isAsync: boolean) => {
-    return await sendCommand(url, 'allVariables', [{ location: userLocation }], isAsync)
+    return await sendCommand(url, {
+        command: 'allVariables', 
+        params: [{ location: userLocation }], 
+        isAsync
+    })
 }
 
 const callTrack = async (url: string, userLocation: string, event: unknown) => {
-    return await sendCommand(url, 'track', [{ location: userLocation }, { value: event }], false)
+    return await sendCommand(url, {
+        command: 'track', 
+        params: [{ location: userLocation }, { value: event }], 
+        isAsync: false
+    })
 }
 
-const callAllFeatures = async (url: string, userLocation: string, isAsync: boolean) => {
-    return await sendCommand(url, 'allFeatures', [{ location: userLocation }], isAsync)
+const callAllFeatures = async (url: string, user: unknown, isAsync: boolean) => {
+    return await sendCommand(url, {
+        command: 'allFeatures', 
+        params: [{ type: 'user' }], 
+        isAsync
+    })
 }
 
 export const waitForRequest = async (
@@ -247,7 +273,7 @@ class BaseTestClient {
         return (new URL(this.clientLocation ?? '', getConnectionStringForProxy(this.sdkName))).href
     }
 
-    async callTrack(userLocation: string, event: unknown, shouldFail: boolean = false) {
+    async callTrack(userLocation: string, event: unknown, shouldFail = false) {
         const result = await callTrack(this.getClientUrl(), userLocation, event)
 
         await checkFailed(result, shouldFail)
@@ -257,7 +283,7 @@ class BaseTestClient {
 }
 
 export class LocalTestClient extends BaseTestClient {
-    async createClient(options: Record<string, unknown> = {}, sdkKey?: string | null, shouldFail: boolean = false) {
+    async createClient(options: Record<string, unknown> = {}, sdkKey?: string | null, shouldFail = false) {
         if (sdkKey !== undefined) {
             this.sdkKey = sdkKey
         }
@@ -284,7 +310,7 @@ export class LocalTestClient extends BaseTestClient {
         userLocation: string,
         key?: string,
         defaultValue?: any,
-        shouldFail: boolean = false
+        shouldFail = false
     ) {
         const result = await callVariable(
             this.getClientUrl(),
@@ -300,7 +326,7 @@ export class LocalTestClient extends BaseTestClient {
 
     async callAllVariables(
         userLocation: string,
-        shouldFail: boolean = false
+        shouldFail = false
     ) {
         const result = await callAllVariables(this.getClientUrl(), userLocation, false)
 
@@ -309,28 +335,32 @@ export class LocalTestClient extends BaseTestClient {
     }
 
     async callOnClientInitialized() {
-        const response = await sendCommand(this.getClientUrl(), 'onClientInitialized', [], true)
+        const response = await sendCommand(this.getClientUrl(), {
+            command: 'onClientInitialized', params: [], isAsync: true
+        })
 
         await checkFailed(response, false)
     }
 
     async close() {
-        const result = await sendCommand(this.getClientUrl(), 'close', [], true)
+        const result = await sendCommand(this.getClientUrl(), {
+            command: 'close', params: [], isAsync: true
+        })
         await checkFailed(result, false)
     }
 
     async callAllFeatures(
-        userLocation: string,
-        shouldFail: boolean = false
+        user: Record<string, unknown>,
+        shouldFail = false
     ) {
-        const result = await callAllFeatures(this.getClientUrl(), userLocation, false)
+        const result = await callAllFeatures(this.getClientUrl(), user, false)
         await checkFailed(result, shouldFail)
         return result
     }
 }
 
 export class CloudTestClient extends BaseTestClient {
-    async createClient(options: Record<string, unknown> = {}, sdkKey?: string | null, shouldFail: boolean = false) {
+    async createClient(options: Record<string, unknown> = {}, sdkKey?: string | null, shouldFail = false) {
         if (sdkKey !== undefined) {
             this.sdkKey = sdkKey
         }
@@ -358,7 +388,7 @@ export class CloudTestClient extends BaseTestClient {
         userLocation: string,
         key?: string,
         defaultValue?: any,
-        shouldFail: boolean = false
+        shouldFail = false
     ) {
         const result = await callVariable(
             this.getClientUrl(),
@@ -373,7 +403,7 @@ export class CloudTestClient extends BaseTestClient {
 
     async callAllVariables(
         userLocation: string,
-        shouldFail: boolean = false
+        shouldFail = false
     ) {
         const result = await callAllVariables(this.getClientUrl(), userLocation, true)
         await checkFailed(result, shouldFail)
@@ -381,10 +411,10 @@ export class CloudTestClient extends BaseTestClient {
     }
 
     async callAllFeatures(
-        userLocation: string,
-        shouldFail: boolean = false
+        user: Record<string, unknown>,
+        shouldFail = false
     ) {
-        const result = await callAllFeatures(this.getClientUrl(), userLocation, true)
+        const result = await callAllFeatures(this.getClientUrl(), user, true)
         await checkFailed(result, shouldFail)
         return result
     }

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -146,8 +146,8 @@ type CommandBody = {
     command: string,
     isAsync?: boolean,
     params: unknown[],
-    user?: Record<string, unknown>,
-    event?: Record<string, unknown>
+    user?: unknown,
+    event?: unknown
 }
 
 export const sendCommand = async (url: string, body: CommandBody) => {
@@ -200,10 +200,12 @@ const callAllVariables = async (url: string, userLocation: string, isAsync: bool
     })
 }
 
-const callTrack = async (url: string, userLocation: string, event: unknown) => {
+const callTrack = async (url: string, user: unknown, event: unknown) => {
     return await sendCommand(url, {
-        command: 'track', 
-        params: [{ location: userLocation }, { value: event }], 
+        command: 'track',
+        user,
+        event,
+        params: [{ type: 'user' }, { value: event }], 
         isAsync: false
     })
 }
@@ -273,8 +275,8 @@ class BaseTestClient {
         return (new URL(this.clientLocation ?? '', getConnectionStringForProxy(this.sdkName))).href
     }
 
-    async callTrack(userLocation: string, event: unknown, shouldFail = false) {
-        const result = await callTrack(this.getClientUrl(), userLocation, event)
+    async callTrack(user: unknown, event: unknown, shouldFail = false) {
+        const result = await callTrack(this.getClientUrl(), user, event)
 
         await checkFailed(result, shouldFail)
 


### PR DESCRIPTION
# Summary

Use the new location endpoint params on all tests to simplify and consolidate user creation and event creation errors.