### PR TITLE
fix proxy error handling

### DIFF
--- a/proxies/dotnet/Controllers/Location.cs
+++ b/proxies/dotnet/Controllers/Location.cs
@@ -65,13 +65,13 @@ public class LocationController : ControllerBase
         
         try {
            entity = GetEntity(location);
-           parsedParams = ParseParams(body.Params, body.User, body.Event);
         } catch (Exception e) {
             Response.StatusCode = 404;
             return new { message = e.Message };
         }
 
         try {
+            parsedParams = ParseParams(body.Params, body.User, body.Event);
             var result = await InvokeCommand(entity, body.Command, body.IsAsync, parsedParams);
 
             Response.StatusCode = 201;
@@ -85,6 +85,7 @@ public class LocationController : ControllerBase
 
         } catch (Exception e) {
             Response.StatusCode = 200;
+            
 
             if (body.IsAsync) {
                 return new {


### PR DESCRIPTION
Only respond 404 when entity location is not valid.
Otherwise respond with any exception thrown from parsing params.
This will correctly catch errors with constructing User and Event objects