### PR TITLE
call dispose when close is called for C#

### DIFF
--- a/proxies/dotnet/Controllers/Location.cs
+++ b/proxies/dotnet/Controllers/Location.cs
@@ -178,11 +178,7 @@ public class LocationController : ControllerBase
 
         if (parsedCommand == "Close")
         {
-            return new CommandResult
-            {
-                EntityType = "Void",
-                Data = new { }
-            };
+            parsedCommand = "Dispose";
         }
 
         MethodInfo? commandMethod = entity.GetType().GetMethod(parsedCommand);


### PR DESCRIPTION
The naming of the method is based on the `Disposable` pattern in C# so it's a platform-specific difference we should abstract over