### PR TITLE
null check await call

### DIFF
--- a/proxies/dotnet/Controllers/Location.cs
+++ b/proxies/dotnet/Controllers/Location.cs
@@ -85,6 +85,7 @@ public class LocationController : ControllerBase
 
         } catch (Exception e) {
             Response.StatusCode = 200;
+            _logger.LogError(e, "");
             
 
             if (body.IsAsync) {
@@ -192,7 +193,7 @@ public class LocationController : ControllerBase
 
         if (isAsync) {
             dynamic? task = commandMethod?.Invoke(entity, parsedParams.ToArray());
-            result = (await task) ?? result;
+            result = result == null ? result : (await task);
         } else {
             result = commandMethod?.Invoke(entity, parsedParams.ToArray()) ?? result;
         }


### PR DESCRIPTION
Prevent calling `await` if the result is `null` to avoid a cryptic error.