### PR TITLE
test config fetching with etag and failure behaviour

### DIFF
--- a/harness/mockData/index.ts
+++ b/harness/mockData/index.ts
@@ -1,3 +1,4 @@
 export * from './config'
 export * from './features'
 export * from './variables'
+export * from './users'

--- a/harness/mockData/users.ts
+++ b/harness/mockData/users.ts
@@ -1,0 +1,2 @@
+export const shouldBucketUser = { user_id: 'user1', customData: { 'should-bucket': true } }
+


### PR DESCRIPTION
- test that the cached config is used when the reply is 304 not modified
- test that the cached config is used when the reply is a failure, but that it retries that request once
- test that the cached config used when the reply is not valid JSON