### PR TITLE
Fix variable local ordering

### DIFF
--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -218,7 +218,7 @@ describe('Variable Tests - Local', () => {
                 const testClient = new LocalTestClient(name)
 
                 beforeAll(async () => {
-                    const configRequestUrl = `/${testClient.clientLocation}/config/v1/server/${testClient.sdkKey}.json`
+                    const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
                     const interceptor = scope
                         .get(configRequestUrl)
 

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -218,12 +218,13 @@ describe('Variable Tests - Local', () => {
                 const testClient = new LocalTestClient(name)
 
                 beforeAll(async () => {
-                    await testClient.createClient(false)
                     const configRequestUrl = `/${testClient.clientLocation}/config/v1/server/${testClient.sdkKey}.json`
                     const interceptor = scope
                         .get(configRequestUrl)
 
                     interceptor.reply(404)
+
+                    await testClient.createClient(false)
 
                     await waitForRequest(
                         scope,


### PR DESCRIPTION
- reorder the client initialization setup for variable local tests
- fix the URL on the scope interceptor