### PR TITLE
use jest projects to run sdk tests in parallel

### DIFF
--- a/docs/GUIDE.MD
+++ b/docs/GUIDE.MD
@@ -14,7 +14,7 @@ Tests are divided into separate features that are present in each SDK tested by 
 `harness/features/`. There are also helper methods located under `harness/helpers.ts` that can be used to create SDK clients, call certain
 features on the proxy server and return the response, etc.
 
-An important helper method is the `getSDKScope` helper method, which returns the currently running SDK for the current jest project which is runnig. 
+An important helper method is the `getSDKScope` helper method, which returns the currently running SDK name for the current jest project. 
 You can see all the jest projects in `jest.config.js`. All SDK types are defined in: `harness/types/sdks.ts`.
 
 Another useful method is to wrap tests with a `describeCapability` function, passing in a capability listed under `harness/types/capabilities.ts`. 

--- a/docs/GUIDE.MD
+++ b/docs/GUIDE.MD
@@ -14,8 +14,8 @@ Tests are divided into separate features that are present in each SDK tested by 
 `harness/features/`. There are also helper methods located under `harness/helpers.ts` that can be used to create SDK clients, call certain
 features on the proxy server and return the response, etc.
 
-An important helper method is the `forEachSDK` helper method, which can be wrapped around any tests to run the tests for all SDKs listed under
-`harness/types/sdks.ts`.
+An important helper method is the `getSDKScope` helper method, which returns the currently running SDK for the current jest project which is runnig. 
+You can see all the jest projects in `jest.config.js`. All SDK types are defined in: `harness/types/sdks.ts`.
 
 Another useful method is to wrap tests with a `describeCapability` function, passing in a capability listed under `harness/types/capabilities.ts`. 
 This is used to segment different SDKs with different tests that are present on some SDKs but not all, e.g. Python not having a local bucketing capability.

--- a/harness/features/allFeatures.cloud.test.ts
+++ b/harness/features/allFeatures.cloud.test.ts
@@ -1,87 +1,85 @@
 import {
-    forEachSDK,
-    CloudTestClient, describeCapability, expectErrorMessageToBe,
+    CloudTestClient,
+    describeCapability,
+    expectErrorMessageToBe,
+    getSDKScope,
 } from '../helpers'
 import { Capabilities } from '../types'
-import { getServerScope } from '../nock'
 import { expectedFeaturesVariationOn } from '../mockData'
 
-const scope = getServerScope()
-
 describe('allFeatures Tests - Cloud', () => {
-    forEachSDK((name) => {
-        let testClient: CloudTestClient
+    const { sdkName, scope } = getSDKScope()
+    let testClient: CloudTestClient
 
-        beforeEach(async () => {
-            testClient = new CloudTestClient(name)
-            await testClient.createClient({
-                enableCloudBucketing: true,
+    beforeEach(async () => {
+        testClient = new CloudTestClient(sdkName)
+        await testClient.createClient({
+            enableCloudBucketing: true,
+        })
+    })
+
+    describeCapability(sdkName, Capabilities.cloud)(sdkName, () => {
+        it('should return all features without edgeDB', async () => {
+            scope
+                .post(`/client/${testClient.clientId}/v1/features`, (body) => body.user_id === 'user1')
+                .matchHeader('Content-Type', 'application/json')
+                .matchHeader('authorization', testClient.sdkKey)
+                .query((queryObj) => {
+                    return !queryObj.enableEdgeDB
+                })
+                .reply(200, expectedFeaturesVariationOn)
+            const featuresResponse = await testClient.callAllFeatures({
+                user_id: 'user1',
+                customData: { 'should-bucket': true }
+            })
+
+            const features = await featuresResponse.json()
+            expect(features).toMatchObject({
+                entityType: 'Object',
+                data: expectedFeaturesVariationOn,
+                logs: []
             })
         })
 
-        describeCapability(name, Capabilities.cloud)(name, () => {
-            it('should return all features without edgeDB', async () => {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/features`, (body) => body.user_id === 'user1')
-                    .matchHeader('Content-Type', 'application/json')
-                    .matchHeader('authorization', testClient.sdkKey)
-                    .query((queryObj) => {
-                        return !queryObj.enableEdgeDB
-                    })
-                    .reply(200, expectedFeaturesVariationOn)
-                const featuresResponse = await testClient.callAllFeatures({
-                    user_id: 'user1',
-                    customData: { 'should-bucket': true }
-                })
-
-                const features = await featuresResponse.json()
-                expect(features).toMatchObject({
-                    entityType: 'Object',
-                    data: expectedFeaturesVariationOn,
-                    logs: []
-                })
+        it('should return all features with edgeDB', async () => {
+            const edgeDBTestClient = new CloudTestClient(sdkName)
+            await edgeDBTestClient.createClient({
+                enableEdgeDB: true,
+                enableCloudBucketing: true,
             })
 
-            it('should return all features with edgeDB', async () => {
-                const edgeDBTestClient = new CloudTestClient(name)
-                await edgeDBTestClient.createClient({
-                    enableEdgeDB: true,
-                    enableCloudBucketing: true,
+            scope
+                .post(`/client/${edgeDBTestClient.clientId}/v1/features`)
+                .matchHeader('Content-Type', 'application/json')
+                .matchHeader('authorization', edgeDBTestClient.sdkKey)
+                .query((queryObj) => {
+                    return queryObj.enableEdgeDB === 'true'
                 })
+                .reply(200, expectedFeaturesVariationOn)
 
-                scope
-                    .post(`/client/${edgeDBTestClient.clientId}/v1/features`)
-                    .matchHeader('Content-Type', 'application/json')
-                    .matchHeader('authorization', edgeDBTestClient.sdkKey)
-                    .query((queryObj) => {
-                        return queryObj.enableEdgeDB === 'true'
-                    })
-                    .reply(200, expectedFeaturesVariationOn)
-
-                const featuresResponse = await edgeDBTestClient.callAllFeatures({
-                    user_id: 'user1',
-                    customData: { 'should-bucket': true }
-                })
-                const features = await featuresResponse.json()
-                expect(features).toMatchObject({
-                    entityType: 'Object',
-                    data: expectedFeaturesVariationOn,
-                    logs: []
-                })
+            const featuresResponse = await edgeDBTestClient.callAllFeatures({
+                user_id: 'user1',
+                customData: { 'should-bucket': true }
             })
-
-            // TODO DVC-5954 investigate why these were failing on the SDKs
-            it.skip('should throw if features request fails on invalid sdk key', async () => {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/features`)
-                    .reply(401, { message: 'Invalid sdk key' })
-
-                const response = await testClient.callAllFeatures({
-                    user_id: 'user1'
-                }, true)
-                const res = await response.json()
-                expectErrorMessageToBe(res.asyncError, 'Invalid sdk key')
+            const features = await featuresResponse.json()
+            expect(features).toMatchObject({
+                entityType: 'Object',
+                data: expectedFeaturesVariationOn,
+                logs: []
             })
+        })
+
+        // TODO DVC-5954 investigate why these were failing on the SDKs
+        it.skip('should throw if features request fails on invalid sdk key', async () => {
+            scope
+                .post(`/client/${testClient.clientId}/v1/features`)
+                .reply(401, { message: 'Invalid sdk key' })
+
+            const response = await testClient.callAllFeatures({
+                user_id: 'user1'
+            }, true)
+            const res = await response.json()
+            expectErrorMessageToBe(res.asyncError, 'Invalid sdk key')
         })
     })
 })

--- a/harness/features/allFeatures.local.test.ts
+++ b/harness/features/allFeatures.local.test.ts
@@ -1,67 +1,64 @@
 import {
-    forEachSDK,
     LocalTestClient,
-    describeCapability
+    describeCapability,
+    getSDKScope
 } from '../helpers'
 import { Capabilities } from '../types'
-import { getServerScope } from '../nock'
 import { config, expectedFeaturesVariationOn } from '../mockData/config'
 
-const scope = getServerScope()
-
 describe('allFeatures Tests - Local', () => {
-    forEachSDK((name) => {
-        describeCapability(name, Capabilities.local)(name, () => {
-            describe('uninitialized client', () => {
-                let testClient: LocalTestClient
+    const { sdkName, scope } = getSDKScope()
 
-                beforeEach(async () => {
-                    testClient = new LocalTestClient(name)
-                    const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
-                    scope
-                        .get(configRequestUrl)
-                        .times(2)
-                        .reply(500)
-                    await testClient.createClient(true, { configPollingIntervalMS: 60000 })
+    describeCapability(sdkName, Capabilities.local)(sdkName, () => {
+        describe('uninitialized client', () => {
+            let testClient: LocalTestClient
+
+            beforeEach(async () => {
+                testClient = new LocalTestClient(sdkName)
+                const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
+                scope
+                    .get(configRequestUrl)
+                    .times(2)
+                    .reply(500)
+                await testClient.createClient(true, { configPollingIntervalMS: 60000 })
+            })
+
+            it('should return empty object if client is uninitialized',  async () => {
+                const featuresResponse = await testClient.callAllFeatures({
+                    user_id: 'user1',
+                    customData: { 'should-bucket': true }
                 })
+                const features = await featuresResponse.json()
+                expect(features).toMatchObject({})
+            })
+        })
 
-                it('should return empty object if client is uninitialized',  async () => {
-                    const featuresResponse = await testClient.callAllFeatures({
-                        user_id: 'user1',
-                        customData: { 'should-bucket': true }
-                    })
-                    const features = await featuresResponse.json()
-                    expect(features).toMatchObject({})
+        describe('initialized client', () => {
+            let testClient: LocalTestClient
+
+            beforeEach(async () => {
+                testClient = new LocalTestClient(sdkName)
+                scope
+                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                    .reply(200, config)
+                await testClient.createClient(true, { configPollingIntervalMS: 60000 })
+            })
+
+            it('should return all features for user without custom data',  async () => {
+                const featuresResponse = await testClient.callAllFeatures({ user_id: 'user3' })
+                const features = (await featuresResponse.json()).data
+                expect(features).toMatchObject({
+                    'schedule-feature': { ...expectedFeaturesVariationOn['schedule-feature'] }
                 })
             })
 
-            describe('initialized client', () => {
-                let testClient: LocalTestClient
-
-                beforeEach(async () => {
-                    testClient = new LocalTestClient(name)
-                    scope
-                        .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                        .reply(200, config)
-                    await testClient.createClient(true, { configPollingIntervalMS: 60000 })
+            it('should return all features for user with custom data',  async () => {
+                const featuresResponse = await testClient.callAllFeatures({
+                    user_id: 'user1',
+                    customData: { 'should-bucket': true }
                 })
-
-                it('should return all features for user without custom data',  async () => {
-                    const featuresResponse = await testClient.callAllFeatures({ user_id: 'user3' })
-                    const features = (await featuresResponse.json()).data
-                    expect(features).toMatchObject({
-                        'schedule-feature': { ...expectedFeaturesVariationOn['schedule-feature'] }
-                    })
-                })
-
-                it('should return all features for user with custom data',  async () => {
-                    const featuresResponse = await testClient.callAllFeatures({
-                        user_id: 'user1',
-                        customData: { 'should-bucket': true }
-                    })
-                    const features = (await featuresResponse.json()).data
-                    expect(features).toMatchObject(expectedFeaturesVariationOn)
-                })
+                const features = (await featuresResponse.json()).data
+                expect(features).toMatchObject(expectedFeaturesVariationOn)
             })
         })
     })

--- a/harness/features/allVariables.cloud.test.ts
+++ b/harness/features/allVariables.cloud.test.ts
@@ -1,102 +1,102 @@
 import {
     getConnectionStringForProxy,
-    forEachSDK,
-    CloudTestClient, describeCapability,
-    expectErrorMessageToBe
+    CloudTestClient,
+    describeCapability,
+    expectErrorMessageToBe,
+    getSDKScope
 } from '../helpers'
-import { getServerScope } from '../nock'
 import { Capabilities } from '../types'
 import { variables } from '../mockData'
 
 describe('allVariables Tests - Cloud', () => {
-    const scope = getServerScope()
+    const { sdkName, scope } = getSDKScope()
+    console.log(`Running allVariables tests for ${sdkName}`)
 
-    forEachSDK((name: string) => {
-        let url: string
+    let url: string
 
-        let client: CloudTestClient
+    let client: CloudTestClient
 
-        beforeEach(async () => {
-            client = new CloudTestClient(name)
-            url = getConnectionStringForProxy(name)
-            await client.createClient()
+    beforeEach(async () => {
+        client = new CloudTestClient(sdkName)
+        url = getConnectionStringForProxy(sdkName)
+        await client.createClient()
+    })
+
+    describeCapability(sdkName, Capabilities.cloud)(sdkName, () => {
+        it('should return an empty object if variables request fails', async () => {
+            scope
+                .persist() // need to persist because the client will retry on 500
+                .post(`/client/${client.clientId}/v1/variables`)
+                .reply(500)
+
+            const response = await client.callAllVariables({
+                user_id: 'test_user',
+                email: 'user@gmail.com'
+            })
+            const { data: variablesMap } = await response.json()
+
+            expect(variablesMap).toMatchObject({})
         })
 
-        describeCapability(name, Capabilities.cloud)(name, () => {
-            it('should return an empty object if variables request fails', async () => {
-                scope
-                    .persist() // need to persist because the client will retry on 500
-                    .post(`/client/${client.clientId}/v1/variables`)
-                    .reply(500)
+        it('should throw if variables request fails on user error', async () => {
+            scope
+                .post(`/client/${client.clientId}/v1/variables`)
+                .reply(401, { message: 'Invalid sdk token' })
 
-                const response = await client.callAllVariables({
-                    user_id: 'test_user',
-                    email: 'user@gmail.com'
+            const response = await client.callAllVariables({
+                user_id: 'test_user',
+                email: 'user@gmail.com'
+            }, true)
+            const res = await response.json()
+            expectErrorMessageToBe(res.asyncError, 'Invalid sdk token')
+        })
+
+        it('should return a variable map', async () => {
+            scope
+                .post(`/client/${client.clientId}/v1/variables`)
+                .reply(200, variables)
+            const response = await client.callAllVariables({
+                user_id: 'test_user',
+                email: 'user@gmail.com',
+            })
+            const { data: variablesMap, entityType } = await response.json()
+
+            expect(entityType).toEqual('Object')
+            expect(variablesMap).toEqual(variables)
+        })
+
+        it('should make a request to the variables endpoint with edgeDB param to false', async () => {
+            scope
+                .post(`/client/${client.clientId}/v1/variables`)
+                .query((queryObj) => {
+                    return !queryObj.enableEdgeDB
                 })
-                const { data: variablesMap } = await response.json()
+                .reply(200, variables)
 
-                expect(variablesMap).toMatchObject({})
+            await client.callAllVariables({
+                user_id: 'test_user',
+                email: 'user@gmail.com',
+            })
+        })
+
+        it('should make a request to the variables endpoint with edgeDB param to true', async () => {
+            const client = new CloudTestClient(sdkName)
+            scope
+                .post(`/client/${client.clientId}/v1/variables`)
+                .query((queryObj) => {
+                    return queryObj.enableEdgeDB === 'true'
+                })
+                .reply(200, variables)
+
+            await client.createClient({
+                enableEdgeDB: true
             })
 
-            it('should throw if variables request fails on user error', async () => {
-                scope
-                    .post(`/client/${client.clientId}/v1/variables`)
-                    .reply(401, { message: 'Invalid sdk token' })
-
-                const response = await client.callAllVariables({
-                    user_id: 'test_user',
-                    email: 'user@gmail.com'
-                }, true)
-                const res = await response.json()
-                expectErrorMessageToBe(res.asyncError, 'Invalid sdk token')
-            })
-
-            it('should return a variable map', async () => {
-                scope
-                    .post(`/client/${client.clientId}/v1/variables`)
-                    .reply(200, variables)
-                const response = await client.callAllVariables({
-                    user_id: 'test_user',
-                    email: 'user@gmail.com',
-                })
-                const { data: variablesMap, entityType } = await response.json()
-
-                expect(entityType).toEqual('Object')
-                expect(variablesMap).toEqual(variables)
-            })
-
-            it('should make a request to the variables endpoint with edgeDB param to false', async () => {
-                scope
-                    .post(`/client/${client.clientId}/v1/variables`)
-                    .query((queryObj) => {
-                        return !queryObj.enableEdgeDB
-                    })
-                    .reply(200, variables)
-
-                await client.callAllVariables({
-                    user_id: 'test_user',
-                    email: 'user@gmail.com',
-                })
-            })
-
-            it('should make a request to the variables endpoint with edgeDB param to true', async () => {
-                const client = new CloudTestClient(name)
-                scope
-                    .post(`/client/${client.clientId}/v1/variables`)
-                    .query((queryObj) => {
-                        return queryObj.enableEdgeDB === 'true'
-                    })
-                    .reply(200, variables)
-
-                await client.createClient({
-                    enableEdgeDB: true
-                })
-
-                await client.callAllVariables({
-                    user_id: 'test_user',
-                    email: 'user@gmail.com',
-                })
+            await client.callAllVariables({
+                user_id: 'test_user',
+                email: 'user@gmail.com',
             })
         })
     })
+    // })
 })

--- a/harness/features/clientCustomData.test.ts
+++ b/harness/features/clientCustomData.test.ts
@@ -1,88 +1,84 @@
 import {
     getConnectionStringForProxy,
-    forEachSDK,
     LocalTestClient,
     describeCapability,
     hasCapability,
-    waitForRequest
+    waitForRequest,
+    getSDKScope
 } from '../helpers'
 import { Capabilities } from '../types'
 import { config } from '../mockData'
-import { getServerScope } from '../nock'
-
-const scope = getServerScope()
 
 describe('Client Custom Data Tests', () => {
-    forEachSDK((name) => {
-        let url: string
-        beforeAll(async () => {
-            url = getConnectionStringForProxy(name)
+    const { sdkName, scope } = getSDKScope()
+
+    let url: string
+    beforeAll(async () => {
+        url = getConnectionStringForProxy(sdkName)
+    })
+
+    describeCapability(sdkName, Capabilities.clientCustomData)(sdkName, () => {
+        it('should set client custom data and use it for segmentation', async () => {
+            const client = new LocalTestClient(sdkName)
+
+            scope
+                .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
+                .reply(200, config)
+
+            if (hasCapability(sdkName, Capabilities.events)) {
+                scope
+                    .post(`/client/${client.clientId}/v1/events/batch`)
+                    .reply(201)
+            }
+
+            const customData = { 'should-bucket': true }
+            await client.createClient(true)
+            await client.callSetClientCustomData(customData)
+            const user = { user_id: 'test-user' }
+            const response = await client.callVariable(user, 'string-var', 'some-default')
+            const variable = await response.json()
+            expect(variable).toEqual(expect.objectContaining({
+                entityType: 'Variable',
+                data: {
+                    type: 'String',
+                    isDefaulted: false,
+                    key: 'string-var',
+                    defaultValue: 'some-default',
+                    value: 'string'
+                }
+            }))
         })
 
-        describeCapability(name, Capabilities.clientCustomData)(name, () => {
-            it('should set client custom data and use it for segmentation', async () => {
-                const client = new LocalTestClient(name)
+        it('should do nothing when client has not initialized', async () => {
+            const client = new LocalTestClient(sdkName)
+            const configCall = scope
+                .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
 
-                scope
-                    .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
-                    .reply(200, config)
+            configCall
+                .delay(1000)
+                .reply(200, config)
 
-                if (hasCapability(name, Capabilities.events)) {
-                    scope
-                        .post(`/client/${client.clientId}/v1/events/batch`)
-                        .reply(201)
+            const customData = { 'should-bucket': true }
+            await client.createClient(false)
+            await client.callSetClientCustomData(customData)
+            await waitForRequest(scope, configCall, 1000, 'Config request timed out')
+
+            if (hasCapability(sdkName, Capabilities.events)) {
+                scope.post(`/client/${client.clientId}/v1/events/batch`).reply(201)
+            }
+
+            const response = await client.callVariable({ user_id: 'user-id' }, 'string-var', 'some-default')
+            const variable = await response.json()
+            expect(variable).toEqual(expect.objectContaining({
+                entityType: 'Variable',
+                data: {
+                    type: 'String',
+                    isDefaulted: true,
+                    key: 'string-var',
+                    defaultValue: 'some-default',
+                    value: 'some-default'
                 }
-
-
-                const customData = { 'should-bucket': true }
-                await client.createClient(true)
-                await client.callSetClientCustomData(customData)
-                const user = { user_id: 'test-user' }
-                const response = await client.callVariable(user, 'string-var', 'some-default')
-                const variable = await response.json()
-                expect(variable).toEqual(expect.objectContaining({
-                    entityType: 'Variable',
-                    data: {
-                        type: 'String',
-                        isDefaulted: false,
-                        key: 'string-var',
-                        defaultValue: 'some-default',
-                        value: 'string'
-                    }
-                }))
-            })
-
-            it('should do nothing when client has not initialized', async () => {
-                const client = new LocalTestClient(name)
-                const configCall = scope
-                    .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
-
-                configCall
-                    .delay(1000)
-                    .reply(200, config)
-
-                const customData = { 'should-bucket': true }
-                await client.createClient(false)
-                await client.callSetClientCustomData(customData)
-                await waitForRequest(scope, configCall, 1000, 'Config request timed out')
-
-                if (hasCapability(name, Capabilities.events)) {
-                    scope.post(`/client/${client.clientId}/v1/events/batch`).reply(201)
-                }
-
-                const response = await client.callVariable({ user_id: 'user-id' }, 'string-var', 'some-default')
-                const variable = await response.json()
-                expect(variable).toEqual(expect.objectContaining({
-                    entityType: 'Variable',
-                    data: {
-                        type: 'String',
-                        isDefaulted: true,
-                        key: 'string-var',
-                        defaultValue: 'some-default',
-                        value: 'some-default'
-                    }
-                }))
-            })
+            }))
         })
     })
 })

--- a/harness/features/initialize.cloud.test.ts
+++ b/harness/features/initialize.cloud.test.ts
@@ -1,53 +1,55 @@
 import {
     getConnectionStringForProxy,
-    forEachSDK,
-    CloudTestClient, describeCapability, expectErrorMessageToBe
+    CloudTestClient,
+    describeCapability,
+    expectErrorMessageToBe,
+    getSDKScope
 } from '../helpers'
 import { Capabilities } from '../types'
 
 describe('Client Initialize Tests - Cloud', () => {
-    forEachSDK((name) => {
-        let url: string
-        beforeAll(async () => {
-            url = getConnectionStringForProxy(name)
-            const res = await fetch(`${url}/spec`)
-            const response = await res.json()
+    const { sdkName } = getSDKScope()
 
-            expect(response.name).toBeDefined()
-            expect(response.capabilities).toBeDefined()
+    let url: string
+    beforeAll(async () => {
+        url = getConnectionStringForProxy(sdkName)
+        const res = await fetch(`${url}/spec`)
+        const response = await res.json()
+
+        expect(response.name).toBeDefined()
+        expect(response.capabilities).toBeDefined()
+    })
+
+    describeCapability(sdkName, Capabilities.cloud)(sdkName, () => {
+        it('should throw an exception and return no location if invalid SDK token is sent', async () => {
+            const client = new CloudTestClient(sdkName)
+            const response = await client.createClient({}, 'invalidKey', true)
+            const body = await response.json()
+            expectErrorMessageToBe(
+                body.exception,
+                'Invalid environment key provided. Please call initialize with a valid server environment key'
+            )
+            const createdClientId = response.headers.get('location')
+            expect(createdClientId).toBeNull()
         })
 
-        describeCapability(name, Capabilities.cloud)(name, () => {
-            it('should throw an exception and return no location if invalid SDK token is sent', async () => {
-                const client = new CloudTestClient(name)
-                const response = await client.createClient({}, 'invalidKey', true)
-                const body = await response.json()
-                expectErrorMessageToBe(
-                    body.exception,
-                    'Invalid environment key provided. Please call initialize with a valid server environment key'
-                )
-                const createdClientId = response.headers.get('location')
-                expect(createdClientId).toBeNull()
-            })
+        it('should throw an exception and return no location if no SDK token is sent', async () => {
+            const client = new CloudTestClient(sdkName)
+            const response = await client.createClient({}, null, true)
+            const body = await response.json()
+            expectErrorMessageToBe(
+                body.exception,
+                'Missing environment key! Call initialize with a valid environment key'
+            )
+            const createdClientId = response.headers.get('location')
+            expect(createdClientId).toBeNull()
+        })
 
-            it('should throw an exception and return no location if no SDK token is sent', async () => {
-                const client = new CloudTestClient(name)
-                const response = await client.createClient({}, null, true)
-                const body = await response.json()
-                expectErrorMessageToBe(
-                    body.exception,
-                    'Missing environment key! Call initialize with a valid environment key'
-                )
-                const createdClientId = response.headers.get('location')
-                expect(createdClientId).toBeNull()
-            })
-
-            it('should return client object location if SDK token is correct', async () => {
-                const client = new CloudTestClient(name)
-                const response = await client.createClient({})
-                const body = await response.json()
-                expect(body.message).toBe('success')
-            })
+        it('should return client object location if SDK token is correct', async () => {
+            const client = new CloudTestClient(sdkName)
+            const response = await client.createClient({})
+            const body = await response.json()
+            expect(body.message).toBe('success')
         })
     })
 })

--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -1,209 +1,206 @@
 import {
-    forEachSDK,
     wait,
     LocalTestClient,
     describeCapability,
     expectErrorMessageToBe,
-    hasCapability
+    hasCapability,
+    getSDKScope
 } from '../helpers'
 import { Capabilities } from '../types'
 import { config, shouldBucketUser } from '../mockData'
-import { getServerScope } from '../nock'
 
 describe('Initialize Tests - Local', () => {
-    const scope = getServerScope()
+    const { sdkName, scope } = getSDKScope()
 
-    forEachSDK((name: string) => {
-        describeCapability(name, Capabilities.local)(name, () => {
-            it('should error when SDK key is missing', async () => {
-                const testClient = new LocalTestClient(name)
-                const response = await testClient.createClient(true, {}, null, true)
-                const { exception } = await response.json()
+    describeCapability(sdkName, Capabilities.local)(sdkName, () => {
+        it('should error when SDK key is missing', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            const response = await testClient.createClient(true, {}, null, true)
+            const { exception } = await response.json()
 
-                expectErrorMessageToBe(
-                    exception,
-                    'Missing SDK key! Call initialize with a valid SDK key'
-                )
-            })
+            expectErrorMessageToBe(
+                exception,
+                'Missing SDK key! Call initialize with a valid SDK key'
+            )
+        })
 
-            it('should error when SDK key is invalid', async () => {
-                const testClient = new LocalTestClient(name)
-                const response = await testClient.createClient(true, {}, 'invalid key', true)
-                const { exception } = await response.json()
+        it('should error when SDK key is invalid', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            const response = await testClient.createClient(true, {}, 'invalid key', true)
+            const { exception } = await response.json()
 
-                expectErrorMessageToBe(
-                    exception,
-                    'Invalid SDK key provided. Please call initialize with a valid server SDK key'
-                )
-            })
+            expectErrorMessageToBe(
+                exception,
+                'Invalid SDK key provided. Please call initialize with a valid server SDK key'
+            )
+        })
 
-            it('initializes correctly on valid data', async () => {
-                const testClient = new LocalTestClient(name)
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(200, config)
+        it('initializes correctly on valid data', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(200, config)
 
-                const response = await testClient.createClient(true, { configPollingIntervalMS: 10000 })
-                const { message } = await response.json()
+            const response = await testClient.createClient(true, { configPollingIntervalMS: 10000 })
+            const { message } = await response.json()
 
-                expect(message).toEqual('success')
-            })
+            expect(message).toEqual('success')
+        })
 
-            it('calls initialize promise/callback when config is successfully retrieved', async () => {
-                const testClient = new LocalTestClient(name)
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(200, config)
+        it('calls initialize promise/callback when config is successfully retrieved', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(200, config)
 
-                await testClient.createClient(true, { configPollingIntervalMS: 10000 })
-            })
+            await testClient.createClient(true, { configPollingIntervalMS: 10000 })
+        })
 
-            it('calls initialize promise/callback when config fails to be retrieved', async () => {
-                const testClient = new LocalTestClient(name)
+        it('calls initialize promise/callback when config fails to be retrieved', async () => {
+            const testClient = new LocalTestClient(sdkName)
 
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .times(2)
-                    .reply(500)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .times(2)
+                .reply(500)
 
-                await testClient.createClient(true, { configPollingIntervalMS: 10000 })
-            })
+            await testClient.createClient(true, { configPollingIntervalMS: 10000 })
+        })
 
-            // TODO DVC-6016 investigate why these were failing on the nodeJS SDK
-            it.skip('stops the polling interval when the sdk key is invalid and cdn responds 403,' +
-                ' throws error', async () => {
-                const testClient = new LocalTestClient(name)
+        // TODO DVC-6016 investigate why these were failing on the nodeJS SDK
+        it.skip('stops the polling interval when the sdk key is invalid and cdn responds 403,' +
+            ' throws error', async () => {
+            const testClient = new LocalTestClient(sdkName)
 
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(403)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(403)
 
-                const response =
-                    await testClient.createClient(true, { configPollingIntervalMS: 1000 }, testClient.sdkKey, true)
-                const { exception } = await response.json()
+            const response =
+                await testClient.createClient(true, { configPollingIntervalMS: 1000 }, testClient.sdkKey, true)
+            const { exception } = await response.json()
 
-                expectErrorMessageToBe(
-                    exception,
-                    'Invalid environment key provided. Please call initialize with a valid server environment key'
-                )
+            expectErrorMessageToBe(
+                exception,
+                'Invalid environment key provided. Please call initialize with a valid server environment key'
+            )
 
-            })
+        })
 
-            it('fetches config again after 3 seconds when config polling interval is overriden', async () => {
-                const testClient = new LocalTestClient(name)
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .times(2)
-                    .reply(200, config)
+        it('fetches config again after 3 seconds when config polling interval is overriden', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .times(2)
+                .reply(200, config)
 
-                await testClient.createClient(true, { configPollingIntervalMS: 3000 })
+            await testClient.createClient(true, { configPollingIntervalMS: 3000 })
 
-                expect(scope.pendingMocks().length).toEqual(1)
+            expect(scope.pendingMocks().length).toEqual(1)
 
-                await wait(3100)
-            }, 5000)
+            await wait(3100)
+        }, 5000)
 
-            it('uses the same config if the etag matches', async () => {
-                const testClient = new LocalTestClient(name)
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(200, config)
+        it('uses the same config if the etag matches', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(200, config)
 
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .matchHeader('If-None-Match', (value) => {
-                        return true
-                    })
-                    .reply(304, {})
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .matchHeader('If-None-Match', (value) => {
+                    return true
+                })
+                .reply(304, {})
 
-                await testClient.createClient(true, { configPollingIntervalMS: 1000 })
+            await testClient.createClient(true, { configPollingIntervalMS: 1000 })
 
-                expect(scope.pendingMocks().length).toEqual(1)
+            expect(scope.pendingMocks().length).toEqual(1)
 
-                await wait(1100)
-                expect(scope.pendingMocks().length).toEqual(0)
+            await wait(1100)
+            expect(scope.pendingMocks().length).toEqual(0)
 
-                if (hasCapability(name, Capabilities.events)) {
-                    scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
-                }
+            if (hasCapability(sdkName, Capabilities.events)) {
+                scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+            }
 
-                // make sure the original config is still in use
-                const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
-                expect((await variable.json()).data.value).toEqual(1)
-            })
+            // make sure the original config is still in use
+            const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
+            expect((await variable.json()).data.value).toEqual(1)
+        })
 
-            it('uses the same config if the refetch fails, after retrying once', async () => {
-                const testClient = new LocalTestClient(name)
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(200, config)
+        it('uses the same config if the refetch fails, after retrying once', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(200, config)
 
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .times(2)
-                    .reply(503, {})
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .times(2)
+                .reply(503, {})
 
-                await testClient.createClient(true, { configPollingIntervalMS: 1000 })
+            await testClient.createClient(true, { configPollingIntervalMS: 1000 })
 
-                expect(scope.pendingMocks().length).toEqual(1)
+            expect(scope.pendingMocks().length).toEqual(1)
 
-                await wait(1500)
-                expect(scope.pendingMocks().length).toEqual(0)
-                // make sure the original config is still in use
-                if (hasCapability(name, Capabilities.events)) {
-                    scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
-                }
-                const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
-                expect((await variable.json()).data.value).toEqual(1)
-            })
+            await wait(1500)
+            expect(scope.pendingMocks().length).toEqual(0)
+            // make sure the original config is still in use
+            if (hasCapability(sdkName, Capabilities.events)) {
+                scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+            }
+            const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
+            expect((await variable.json()).data.value).toEqual(1)
+        })
 
-            it('uses the same config if the response is invalid JSON', async () => {
-                const testClient = new LocalTestClient(name)
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(200, config)
+        it('uses the same config if the response is invalid JSON', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(200, config)
 
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(200, "I'm not JSON!")
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(200, 'I\'m not JSON!')
 
-                await testClient.createClient(true, { configPollingIntervalMS: 1000 })
+            await testClient.createClient(true, { configPollingIntervalMS: 1000 })
 
-                expect(scope.pendingMocks().length).toEqual(1)
+            expect(scope.pendingMocks().length).toEqual(1)
 
-                await wait(1200)
-                expect(scope.pendingMocks().length).toEqual(0)
-                // make sure the original config is still in use
-                if (hasCapability(name, Capabilities.events)) {
-                    scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
-                }
-                const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
-                expect((await variable.json()).data.value).toEqual(1)
-            })
+            await wait(1200)
+            expect(scope.pendingMocks().length).toEqual(0)
+            // make sure the original config is still in use
+            if (hasCapability(sdkName, Capabilities.events)) {
+                scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+            }
+            const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
+            expect((await variable.json()).data.value).toEqual(1)
+        })
 
-            it('uses the same config if the response is valid JSON but invalid data', async () => {
-                const testClient = new LocalTestClient(name)
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(200, config)
+        it('uses the same config if the response is valid JSON but invalid data', async () => {
+            const testClient = new LocalTestClient(sdkName)
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(200, config)
 
-                scope
-                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                    .reply(200, "{\"snatch_movie_quote\": \"d'ya like dags?\"}")
+            scope
+                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .reply(200, '{"snatch_movie_quote": "d\'ya like dags?"}')
 
-                await testClient.createClient(true, { configPollingIntervalMS: 1000 })
+            await testClient.createClient(true, { configPollingIntervalMS: 1000 })
 
-                expect(scope.pendingMocks().length).toEqual(1)
+            expect(scope.pendingMocks().length).toEqual(1)
 
-                await wait(1200)
-                expect(scope.pendingMocks().length).toEqual(0)
-                // make sure the original config is still in use
-                if (hasCapability(name, Capabilities.events)) {
-                    scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
-                }
-                const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
-                expect((await variable.json()).data.value).toEqual(1)
-            })
+            await wait(1200)
+            expect(scope.pendingMocks().length).toEqual(0)
+            // make sure the original config is still in use
+            if (hasCapability(sdkName, Capabilities.events)) {
+                scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+            }
+            const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
+            expect((await variable.json()).data.value).toEqual(1)
         })
     })
 })

--- a/harness/features/track.cloud.test.ts
+++ b/harness/features/track.cloud.test.ts
@@ -1,126 +1,123 @@
 import {
-    getConnectionStringForProxy,
-    forEachSDK,
     waitForRequest,
-    CloudTestClient, describeCapability, expectErrorMessageToBe, getPlatformBySdkName,
+    CloudTestClient,
+    describeCapability,
+    expectErrorMessageToBe,
+    getPlatformBySdkName,
+    getSDKScope,
 } from '../helpers'
 import { Capabilities } from '../types'
-import { getServerScope } from '../nock'
-
-const scope = getServerScope()
 
 describe('Track Tests - Cloud', () => {
+    const { sdkName, scope } = getSDKScope()
     const validUserId = 'user1'
-    forEachSDK((name) => {
-        const expectedPlatform = getPlatformBySdkName(name, false)
-        let url: string
 
-        let client: CloudTestClient
+    const expectedPlatform = getPlatformBySdkName(sdkName, false)
 
-        beforeEach(async () => {
-            client = new CloudTestClient(name)
-            url = getConnectionStringForProxy(name)
-            await client.createClient()
-        })
+    let client: CloudTestClient
 
-        afterEach(() => {
-            jest.clearAllMocks()
-        })
-
-        describeCapability(name, Capabilities.cloud)(name, () => {
-            it('should complain if event type not set', async () => {
-                const trackResponse = await client.callTrack({ user_id: validUserId }, { target: 1 }, true)
-                const res = await trackResponse.json()
-                expectErrorMessageToBe(res.asyncError, 'Invalid Event')
-            })
-
-            it('should call events API to track event', async () => {
-                let eventBody = {}
-                const eventType = 'pageNavigated'
-                const variableId = 'string-var'
-                const value = 1
-
-                const interceptor = scope
-                    .post(`/client/${client.clientId}/v1/track`)
-
-                interceptor.matchHeader('Content-Type', 'application/json')
-                interceptor.reply((uri, body) => {
-                    eventBody = body
-                    return [201, { success: true }]
-                })
-
-                await client.callTrack({ user_id: validUserId },
-                    { type: eventType, target: variableId, value })
-
-                await waitForRequest(scope, interceptor, 550, 'Event callback timed out')
-
-                expectEventBody(eventBody, variableId, eventType, value)
-            })
-
-            it('should retry events API on failed request', async () => {
-                let eventBody = {}
-
-                const eventType = 'buttonClicked'
-                const variableId = 'json-var'
-                const value = 1
-
-                scope
-                    .post(`/client/${client.clientId}/v1/track`)
-                    .matchHeader('Content-Type', 'application/json')
-                    .reply(519, {})
-
-                const interceptor = scope
-                    .post(`/client/${client.clientId}/v1/track`)
-                interceptor.matchHeader('Content-Type', 'application/json')
-                interceptor.reply((uri, body) => {
-                    eventBody = body
-                    return [201, { success: true }]
-                })
-
-                const trackResponse = await client.callTrack({ user_id: validUserId },
-                    { type: eventType, target: variableId, value })
-
-                await trackResponse.json()
-
-                await waitForRequest(scope, interceptor, 550, 'Event callback timed out')
-
-                expectEventBody(eventBody, variableId, eventType, value)
-            })
-
-            it('should throw if track request fails on invalid sdk key', async () => {
-                scope
-                    .post(`/client/${client.clientId}/v1/track`)
-                    .reply(401, { message: 'Invalid sdk key' })
-
-                const response = await client.callTrack({
-                    user_id: 'user1'
-                }, { type: 'eventType' },true)
-                const res = await response.json()
-                expectErrorMessageToBe(res.asyncError, 'Invalid sdk key')
-            })
-
-        })
-
-        const expectEventBody = (
-            body: Record<string, unknown>,
-            variableId: string,
-            eventType: string,
-            value?: number,
-        ) => {
-            expect(body).toEqual({
-                user: expect.objectContaining({
-                    platform: expectedPlatform,
-                    sdkType: 'server',
-                    user_id: validUserId,
-                }),
-                events: [
-                    expect.objectContaining({
-                        type: eventType,
-                        target: variableId,
-                        value: value !== undefined ? value : 1,
-                    })
-                ]
-            })
-        }
+    beforeEach(async () => {
+        client = new CloudTestClient(sdkName)
+        await client.createClient()
     })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describeCapability(sdkName, Capabilities.cloud)(sdkName, () => {
+        it('should complain if event type not set', async () => {
+            const trackResponse = await client.callTrack({ user_id: validUserId }, { target: 1 }, true)
+            const res = await trackResponse.json()
+            expectErrorMessageToBe(res.asyncError, 'Invalid Event')
+        })
+
+        it('should call events API to track event', async () => {
+            let eventBody = {}
+            const eventType = 'pageNavigated'
+            const variableId = 'string-var'
+            const value = 1
+
+            const interceptor = scope
+                .post(`/client/${client.clientId}/v1/track`)
+
+            interceptor.matchHeader('Content-Type', 'application/json')
+            interceptor.reply((uri, body) => {
+                eventBody = body
+                return [201, { success: true }]
+            })
+
+            await client.callTrack({ user_id: validUserId },
+                { type: eventType, target: variableId, value })
+
+            await waitForRequest(scope, interceptor, 550, 'Event callback timed out')
+
+            expectEventBody(eventBody, variableId, eventType, value)
+        })
+
+        it('should retry events API on failed request', async () => {
+            let eventBody = {}
+
+            const eventType = 'buttonClicked'
+            const variableId = 'json-var'
+            const value = 1
+
+            scope
+                .post(`/client/${client.clientId}/v1/track`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(519, {})
+
+            const interceptor = scope
+                .post(`/client/${client.clientId}/v1/track`)
+            interceptor.matchHeader('Content-Type', 'application/json')
+            interceptor.reply((uri, body) => {
+                eventBody = body
+                return [201, { success: true }]
+            })
+
+            const trackResponse = await client.callTrack({ user_id: validUserId },
+                { type: eventType, target: variableId, value })
+
+            await trackResponse.json()
+
+            await waitForRequest(scope, interceptor, 550, 'Event callback timed out')
+
+            expectEventBody(eventBody, variableId, eventType, value)
+        })
+
+        it('should throw if track request fails on invalid sdk key', async () => {
+            scope
+                .post(`/client/${client.clientId}/v1/track`)
+                .reply(401, { message: 'Invalid sdk key' })
+
+            const response = await client.callTrack({
+                user_id: 'user1'
+            }, { type: 'eventType' },true)
+            const res = await response.json()
+            expectErrorMessageToBe(res.asyncError, 'Invalid sdk key')
+        })
+
+    })
+
+    const expectEventBody = (
+        body: Record<string, unknown>,
+        variableId: string,
+        eventType: string,
+        value?: number,
+    ) => {
+        expect(body).toEqual({
+            user: expect.objectContaining({
+                platform: expectedPlatform,
+                sdkType: 'server',
+                user_id: validUserId,
+            }),
+            events: [
+                expect.objectContaining({
+                    type: eventType,
+                    target: variableId,
+                    value: value !== undefined ? value : 1,
+                })
+            ]
+        })
+    }
 })

--- a/harness/features/track.local.test.ts
+++ b/harness/features/track.local.test.ts
@@ -1,106 +1,173 @@
 import {
     getConnectionStringForProxy,
-    forEachSDK,
     wait,
     waitForRequest,
-    LocalTestClient, describeCapability, expectErrorMessageToBe, getPlatformBySdkName,
+    LocalTestClient,
+    describeCapability,
+    expectErrorMessageToBe,
+    getPlatformBySdkName,
+    getSDKScope,
 } from '../helpers'
 import { Capabilities } from '../types'
-import { getServerScope } from '../nock'
 import { config } from '../mockData'
 import { optionalEventFields, optionalUserEventFields } from '../mockData/events'
 
-const scope = getServerScope()
-
 describe('Track Tests - Local', () => {
+    const { sdkName, scope } = getSDKScope()
     const validUserId = 'user1'
-    forEachSDK((name) => {
-        const expectedPlatform = getPlatformBySdkName(name, true)
 
-        let url: string
-        const eventFlushIntervalMS = 1000
+    const expectedPlatform = getPlatformBySdkName(sdkName, true)
 
-        describeCapability(name, Capabilities.local, Capabilities.events)(name, () => {
+    let url: string
+    const eventFlushIntervalMS = 1000
 
-            let client: LocalTestClient
+    describeCapability(sdkName, Capabilities.local, Capabilities.events)(sdkName, () => {
+        let client: LocalTestClient
 
-            beforeEach(async () => {
-                client = new LocalTestClient(name)
-                url = getConnectionStringForProxy(name)
+        beforeEach(async () => {
+            client = new LocalTestClient(sdkName)
+            url = getConnectionStringForProxy(sdkName)
 
-                scope
-                    .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
-                    .reply(200, config)
+            scope
+                .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
+                .reply(200, config)
 
-                await client.createClient(true, {
-                    eventFlushIntervalMS: eventFlushIntervalMS,
-                    logLevel: 'debug',
-                    configPollingIntervalMS: 1000 * 60
+            await client.createClient(true, {
+                eventFlushIntervalMS: eventFlushIntervalMS,
+                logLevel: 'debug',
+                configPollingIntervalMS: 1000 * 60
+            })
+        })
+
+        describe('Expect no events sent', () => {
+            it('should not send an event if the event type not set', async () => {
+                const trackResponse = await client.callTrack({ user_id: validUserId }, {}, true)
+
+                const res = await trackResponse.json()
+                expectErrorMessageToBe(res.exception, 'Missing parameter: type')
+
+                // wait for 2 event flush to ensure no flush happens, if it fails it will get caught by
+                // the global assertNoUnmatchedRequests and fail this testcase
+                await wait(eventFlushIntervalMS * 2)
+            })
+        })
+
+        describe('Expect events sent', () => {
+            it('should call events API to track event', async () => {
+                let eventBody = {}
+                const eventType = 'pageNavigated'
+                const variableId = 'string-var'
+                const value = 1
+
+                const interceptor = scope.post(`/client/${client.clientId}/v1/events/batch`)
+                interceptor.reply((uri, body) => {
+                    eventBody = body
+                    return [201]
+                })
+
+                const trackResponse = await client.callTrack({ user_id: validUserId },
+                    { type: eventType, target: 'string-var', value: value })
+
+                await trackResponse.json()
+                await waitForRequest(scope, interceptor, eventFlushIntervalMS * 2, 'Event callback timed out')
+
+                expect(eventBody).toEqual({
+                    batch: [
+                        {
+                            user: {
+                                ...optionalUserEventFields,
+                                platform: expectedPlatform,
+                                sdkType: 'server',
+                                user_id: validUserId,
+                            },
+                            events: [
+                                {
+                                    ...optionalEventFields,
+                                    type: 'customEvent',
+                                    featureVars: {
+                                        '6386813a59f1b81cc9e6c68d': '6386813a59f1b81cc9e6c693'
+                                    },
+                                    metaData: expect.toBeNil(),
+                                    customType: eventType,
+                                    target: variableId,
+                                    value: value,
+                                    user_id: validUserId,
+                                }
+                            ]
+                        },
+                    ],
                 })
             })
 
-            describe('Expect no events sent', () => {
-                it('should not send an event if the event type not set', async () => {
-                    const trackResponse = await client.callTrack({ user_id: validUserId }, {}, true)
+            it('should call events API to track 2 events', async () => {
+                let eventBody = {}
+                // const eventType = 'buttonClicked'
+                const eventType = 'buttonClicked'
+                const variableId = 'string-var'
+                const value = 2
 
-                    const res = await trackResponse.json()
-                    expectErrorMessageToBe(res.exception, 'Missing parameter: type')
+                // const eventType2 = 'textChanged'
+                const eventType2 = 'textChanged'
+                const variableId2 = 'json-var'
+                const value2 = 3
 
-                    // wait for 2 event flush to ensure no flush happens, if it fails it will get caught by
-                    // the global assertNoUnmatchedRequests and fail this testcase
-                    await wait(eventFlushIntervalMS * 2)
+                const interceptor = scope.post(`/client/${client.clientId}/v1/events/batch`)
+                interceptor.reply((uri, body) => {
+                    eventBody = body
+                    return [201]
                 })
-            })
 
-            describe('Expect events sent', () => {
-                it('should call events API to track event', async () => {
-                    let eventBody = {}
-                    const eventType = 'pageNavigated'
-                    const variableId = 'string-var'
-                    const value = 1
+                await client.callTrack({ user_id: validUserId },
+                    { type: eventType, target: variableId, value: value })
+                await client.callTrack({ user_id: validUserId },
+                    { type: eventType2, target: variableId2, value: value2 })
 
-                    const interceptor = scope.post(`/client/${client.clientId}/v1/events/batch`)
-                    interceptor.reply((uri, body) => {
-                        eventBody = body
-                        return [201]
-                    })
+                await waitForRequest(scope, interceptor, eventFlushIntervalMS * 2, 'Event callback timed out')
 
-                    const trackResponse = await client.callTrack({ user_id: validUserId },
-                        { type: eventType, target: 'string-var', value: value })
-
-                    await trackResponse.json()
-                    await waitForRequest(scope, interceptor, eventFlushIntervalMS * 2, 'Event callback timed out')
-
-                    expect(eventBody).toEqual({
-                        batch: [
-                            {
-                                user: {
-                                    ...optionalUserEventFields,
-                                    platform: expectedPlatform,
-                                    sdkType: 'server',
+                expect(eventBody).toEqual({
+                    batch: [
+                        {
+                            user: {
+                                ...optionalUserEventFields,
+                                platform: expectedPlatform,
+                                sdkType: 'server',
+                                user_id: validUserId,
+                            },
+                            events: [
+                                {
+                                    ...optionalEventFields,
+                                    type: 'customEvent',
+                                    featureVars: {
+                                        '6386813a59f1b81cc9e6c68d': '6386813a59f1b81cc9e6c693'
+                                    },
+                                    metaData: expect.toBeNil(),
+                                    customType: eventType,
+                                    target: variableId,
+                                    value: value,
                                     user_id: validUserId,
                                 },
-                                events: [
-                                    {
-                                        ...optionalEventFields,
-                                        type: 'customEvent',
-                                        featureVars: {
-                                            "6386813a59f1b81cc9e6c68d": "6386813a59f1b81cc9e6c693"
-                                        },
-                                        metaData: expect.toBeNil(),
-                                        customType: eventType,
-                                        target: variableId,
-                                        value: value,
-                                        user_id: validUserId,
-                                    }
-                                ]
-                            },
-                        ],
-                    })
+                                {
+                                    ...optionalEventFields,
+                                    type: 'customEvent',
+                                    featureVars: {
+                                        '6386813a59f1b81cc9e6c68d': '6386813a59f1b81cc9e6c693'
+                                    },
+                                    metaData: expect.toBeNil(),
+                                    customType: eventType2,
+                                    target: variableId2,
+                                    value: value2,
+                                    user_id: validUserId,
+                                }
+                            ]
+                        },
+                    ],
                 })
+            })
 
-                it('should call events API to track 2 events', async () => {
+            it('should retry events API call to track 2 events and check interval of events is in specified window',
+                async () => {
                     let eventBody = {}
+                    const timestamps = []
                     // const eventType = 'buttonClicked'
                     const eventType = 'buttonClicked'
                     const variableId = 'string-var'
@@ -111,9 +178,21 @@ describe('Track Tests - Local', () => {
                     const variableId2 = 'json-var'
                     const value2 = 3
 
+                    let startDate = Date.now()
+                    scope
+                        .post(`/client/${client.clientId}/v1/events/batch`)
+                        .matchHeader('Content-Type', 'application/json')
+                        .times(2)
+                        .reply((uri, body) => {
+                            timestamps.push(Date.now() - startDate)
+                            startDate = Date.now()
+                            return [519]
+                        })
+
                     const interceptor = scope.post(`/client/${client.clientId}/v1/events/batch`)
                     interceptor.reply((uri, body) => {
                         eventBody = body
+                        timestamps.push(Date.now() - startDate)
                         return [201]
                     })
 
@@ -122,7 +201,18 @@ describe('Track Tests - Local', () => {
                     await client.callTrack({ user_id: validUserId },
                         { type: eventType2, target: variableId2, value: value2 })
 
-                    await waitForRequest(scope, interceptor, eventFlushIntervalMS * 2, 'Event callback timed out')
+                    await waitForRequest(scope, interceptor, eventFlushIntervalMS * 5, 'Event callback timed out')
+                    //wait for a total of 2(failed) 1(passed) and 2 extra flushes (safety) to happen
+                    //this is to ensure that another flush does not happen
+                    //as it would be caught globally and fail this test case
+                    //the extra flush would be caught by the global assertNoUnmatchedRequests
+
+                    let total = 0
+                    for (let i = 0; i < timestamps.length; i++) {
+                        const time = timestamps[i]
+                        total += time
+                    }
+                    const avg = total / timestamps.length
 
                     expect(eventBody).toEqual({
                         batch: [
@@ -135,22 +225,24 @@ describe('Track Tests - Local', () => {
                                 },
                                 events: [
                                     {
-                                        ...optionalEventFields,
                                         type: 'customEvent',
+                                        customType: eventType,
+                                        clientDate: expect.any(String),
+                                        date: expect.toBeOneOf([null, undefined, expect.any(String)]),
                                         featureVars: {
-                                            "6386813a59f1b81cc9e6c68d": "6386813a59f1b81cc9e6c693"
+                                            '6386813a59f1b81cc9e6c68d': '6386813a59f1b81cc9e6c693'
                                         },
                                         metaData: expect.toBeNil(),
-                                        customType: eventType,
                                         target: variableId,
                                         value: value,
                                         user_id: validUserId,
                                     },
                                     {
-                                        ...optionalEventFields,
                                         type: 'customEvent',
+                                        clientDate: expect.any(String),
+                                        date: expect.toBeOneOf([null, undefined, expect.any(String)]),
                                         featureVars: {
-                                            "6386813a59f1b81cc9e6c68d": "6386813a59f1b81cc9e6c693"
+                                            '6386813a59f1b81cc9e6c68d': '6386813a59f1b81cc9e6c693'
                                         },
                                         metaData: expect.toBeNil(),
                                         customType: eventType2,
@@ -162,104 +254,11 @@ describe('Track Tests - Local', () => {
                             },
                         ],
                     })
+
+                    // checking if the failed reqests were made in 10% of the defined interva;
+                    expect(avg).toBeGreaterThanOrEqual(900)
+                    expect(avg).toBeLessThanOrEqual(1100)
                 })
-
-                it('should retry events API call to track 2 events and check interval of events is in specified window',
-                    async () => {
-                        let eventBody = {}
-                        const timestamps = []
-                        // const eventType = 'buttonClicked'
-                        const eventType = 'buttonClicked'
-                        const variableId = 'string-var'
-                        const value = 2
-
-                        // const eventType2 = 'textChanged'
-                        const eventType2 = 'textChanged'
-                        const variableId2 = 'json-var'
-                        const value2 = 3
-
-                        let startDate = Date.now()
-                        scope
-                            .post(`/client/${client.clientId}/v1/events/batch`)
-                            .matchHeader('Content-Type', 'application/json')
-                            .times(2)
-                            .reply((uri, body) => {
-                                timestamps.push(Date.now() - startDate)
-                                startDate = Date.now()
-                                return [519]
-                            })
-
-                        const interceptor = scope.post(`/client/${client.clientId}/v1/events/batch`)
-                        interceptor.reply((uri, body) => {
-                            eventBody = body
-                            timestamps.push(Date.now() - startDate)
-                            return [201]
-                        })
-
-                        await client.callTrack({ user_id: validUserId },
-                            { type: eventType, target: variableId, value: value })
-                        await client.callTrack({ user_id: validUserId },
-                            { type: eventType2, target: variableId2, value: value2 })
-
-                        await waitForRequest(scope, interceptor, eventFlushIntervalMS * 5, 'Event callback timed out')
-                        //wait for a total of 2(failed) 1(passed) and 2 extra flushes (safety) to happen
-                        //this is to ensure that another flush does not happen
-                        //as it would be caught globally and fail this test case
-                        //the extra flush would be caught by the global assertNoUnmatchedRequests
-
-                        let total = 0
-                        for (let i = 0; i < timestamps.length; i++) {
-                            const time = timestamps[i]
-                            total += time
-                        }
-                        const avg = total / timestamps.length
-
-                        expect(eventBody).toEqual({
-                            batch: [
-                                {
-                                    user: {
-                                        ...optionalUserEventFields,
-                                        platform: expectedPlatform,
-                                        sdkType: 'server',
-                                        user_id: validUserId,
-                                    },
-                                    events: [
-                                        {
-                                            type: 'customEvent',
-                                            customType: eventType,
-                                            clientDate: expect.any(String),
-                                            date: expect.toBeOneOf([null, undefined, expect.any(String)]),
-                                            featureVars: {
-                                                "6386813a59f1b81cc9e6c68d": "6386813a59f1b81cc9e6c693"
-                                            },
-                                            metaData: expect.toBeNil(),
-                                            target: variableId,
-                                            value: value,
-                                            user_id: validUserId,
-                                        },
-                                        {
-                                            type: 'customEvent',
-                                            clientDate: expect.any(String),
-                                            date: expect.toBeOneOf([null, undefined, expect.any(String)]),
-                                            featureVars: {
-                                                "6386813a59f1b81cc9e6c68d": "6386813a59f1b81cc9e6c693"
-                                            },
-                                            metaData: expect.toBeNil(),
-                                            customType: eventType2,
-                                            target: variableId2,
-                                            value: value2,
-                                            user_id: validUserId,
-                                        }
-                                    ]
-                                },
-                            ],
-                        })
-
-                        // checking if the failed reqests were made in 10% of the defined interva;
-                        expect(avg).toBeGreaterThanOrEqual(900)
-                        expect(avg).toBeLessThanOrEqual(1100)
-                    })
-            })
         })
     })
 })

--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -1,264 +1,262 @@
 import {
-    forEachSDK,
     forEachVariableType,
     variablesForTypes,
-    CloudTestClient, describeCapability, expectErrorMessageToBe
+    CloudTestClient,
+    describeCapability,
+    expectErrorMessageToBe,
+    getSDKScope
 } from '../helpers'
 import { Capabilities } from '../types'
-import { getServerScope } from '../nock'
-
-// This is our proxy scope that is used to mock endpoints that are called in the SDK
-const scope = getServerScope()
 
 describe('Variable Tests - Cloud', () => {
-    // This helper method enumerates all the SDKs and calls each test suite
-    // for each SDK, and creates a test client from the name.
+    // This helper method fetches the current SDK we are testing for the current jest project (see jest.config.js).
     // All supported SDKs can be found under harness/types/sdks.ts
-    forEachSDK((name) => {
-        let testClient: CloudTestClient
+    // it also returns our proxy scope that is used to mock endpoints that are called in the SDK.
+    const { sdkName, scope } = getSDKScope()
 
-        beforeEach(async () => {
-            testClient = new CloudTestClient(name)
-            // Creating a client will pass to the proxy server by default:
-            // - sdk key based on the client id created when creating the client
-            // - urls for the bucketing/config/events endpoints to redirect traffic
-            // into the proxy server so nock can mock out the responses
-            // - options like should wait for initialization, or should
-            // expect it to error out
-            await testClient.createClient({
-                enableCloudBucketing: true
-            })
+    let testClient: CloudTestClient
+
+    beforeEach(async () => {
+        testClient = new CloudTestClient(sdkName)
+        // Creating a client will pass to the proxy server by default:
+        // - sdk key based on the client id created when creating the client
+        // - urls for the bucketing/config/events endpoints to redirect traffic
+        // into the proxy server so nock can mock out the responses
+        // - options like should wait for initialization, or should
+        // expect it to error out
+        await testClient.createClient({
+            enableCloudBucketing: true
+        })
+    })
+
+    // This describeCapability only runs if the SDK has the "cloud" capability.
+    // Capabilities are located under harness/types/capabilities and follow the same
+    // name mapping from the sdks.ts file under harness/types/sdks.ts
+    describeCapability(sdkName, Capabilities.cloud)(sdkName, () => {
+        it('will throw error variable called with invalid key', async () => {
+            // Helper method calls the proxy server to trigger the "variable" method in
+            // the SDK
+            const variableResponse = await testClient.callVariable(
+                { user_id: 'user1' },
+                null,
+                'default_value',
+                true
+            )
+            const error = await variableResponse.json()
+            // Helper method to equate error messages from the error object returned
+            // from the proxy server
+            expectErrorMessageToBe(error.asyncError, 'Missing parameter: key')
+        })
+        // TODO DVC-5954 investigate why these were failing on the SDKs
+        it.skip('will throw error if variable called with invalid sdk key', async () => {
+            scope
+                .post(`/client/${testClient.clientId}/v1/variable/var_key`)
+                .reply(401, { message: 'Invalid sdk key' })
+
+            // Helper method calls the proxy server to trigger the "variable" method in
+            // the SDK
+            const variableResponse = await testClient.callVariable(
+                { user_id: 'user1' },
+                'var_key',
+                'default_value',
+                true
+            )
+            const error = await variableResponse.json()
+            // Helper method to equate error messages from the error object returned
+            // from the proxy server
+            expectErrorMessageToBe(error.asyncError, 'Invalid sdk key')
         })
 
-        // This describeCapability only runs if the SDK has the "cloud" capability.
-        // Capabilities are located under harness/types/capabilities and follow the same
-        // name mapping from the sdks.ts file under harness/types/sdks.ts
-        describeCapability(name, Capabilities.cloud)(name, () => {
-            it('will throw error variable called with invalid key', async () => {
-                // Helper method calls the proxy server to trigger the "variable" method in
-                // the SDK
-                const variableResponse = await testClient.callVariable(
-                    { user_id: 'user1' },
-                    null,
-                    'default_value',
-                    true
-                )
-                const error = await variableResponse.json()
-                // Helper method to equate error messages from the error object returned
-                // from the proxy server
-                expectErrorMessageToBe(error.asyncError, 'Missing parameter: key')
-            })
-            // TODO DVC-5954 investigate why these were failing on the SDKs
-            it.skip('will throw error if variable called with invalid sdk key', async () => {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/variable/var_key`)
-                    .reply(401, { message: 'Invalid sdk key' })
+        it('will throw error variable called with invalid default value', async () => {
+            const variableResponse = await testClient.callVariable(
+                { user_id: 'user1' },
+                'var_key',
+                null,
+                true
+            )
 
-                // Helper method calls the proxy server to trigger the "variable" method in
-                // the SDK
-                const variableResponse = await testClient.callVariable(
-                    { user_id: 'user1' },
-                    'var_key',
-                    'default_value',
-                    true
-                )
-                const error = await variableResponse.json()
-                // Helper method to equate error messages from the error object returned
-                // from the proxy server
-                expectErrorMessageToBe(error.asyncError, 'Invalid sdk key')
-            })
+            const error = await variableResponse.json()
+            expectErrorMessageToBe(error.asyncError, 'Missing parameter: defaultValue')
+        })
 
-            it('will throw error variable called with invalid default value', async () => {
-                const variableResponse = await testClient.callVariable(
-                    { user_id: 'user1' },
-                    'var_key',
-                    null,
-                    true
-                )
+        it('should call variables API without edgeDB option', async () => {
+            // This allows us to mock out the our specific client (using the clientId),
+            // allowing us to have multiple mock APIs serving different clients without
+            // conflicting. We can match on specific criteria, like headers and the query params
+            // to specify which call we want to mock, and reply with a status code and an object
+            // as a response
+            scope
+                .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
+                .matchHeader('Content-Type', 'application/json')
+                .matchHeader('authorization', testClient.sdkKey)
+                .query((queryObj) => {
+                    return !queryObj.enableEdgeDB
+                })
+                .reply(200, {
+                    key: 'var_key',
+                    value: 'value',
+                    defaultValue: 'default_value',
+                    type: 'String',
+                    isDefaulted: false
+                })
+            const variableResponse = await testClient.callVariable(
+                { user_id: 'user1' },
+                'var_key',
+                'default_value'
+            )
+            await variableResponse.json()
+        })
 
-                const error = await variableResponse.json()
-                expectErrorMessageToBe(error.asyncError, 'Missing parameter: defaultValue')
-            })
+        it('should call variables API with edgeDB option', async () => {
+            const testClient = new CloudTestClient(sdkName)
 
-            it('should call variables API without edgeDB option', async () => {
-                // This allows us to mock out the our specific client (using the clientId),
-                // allowing us to have multiple mock APIs serving different clients without
-                // conflicting. We can match on specific criteria, like headers and the query params
-                // to specify which call we want to mock, and reply with a status code and an object
-                // as a response
-                scope
-                    .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
-                    .matchHeader('Content-Type', 'application/json')
-                    .matchHeader('authorization', testClient.sdkKey)
-                    .query((queryObj) => {
-                        return !queryObj.enableEdgeDB
-                    })
-                    .reply(200, {
-                        key: 'var_key',
-                        value: 'value',
-                        defaultValue: 'default_value',
-                        type: 'String',
-                        isDefaulted: false
-                    })
-                const variableResponse = await testClient.callVariable(
-                    { user_id: 'user1' },
-                    'var_key',
-                    'default_value'
-                )
-                await variableResponse.json()
+            // Some tests require extra params for startup, so we can just create a new test client
+            // for these specific tests.
+            await testClient.createClient({
+                enableCloudBucketing: true,
+                enableEdgeDB: true
             })
 
-            it('should call variables API with edgeDB option', async () => {
-                const testClient = new CloudTestClient(name)
+            scope
+                .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
+                .matchHeader('Content-Type', 'application/json')
+                .matchHeader('authorization', testClient.sdkKey)
+                .query((queryObj) => {
+                    return !!queryObj.enableEdgeDB
+                })
+                .reply(200, {
+                    key: 'var_key',
+                    value: 'value',
+                    defaultValue: 'default_value',
+                    type: 'String',
+                    isDefaulted: false
+                })
+            const variableResponse = await testClient.callVariable(
+                { user_id: 'user1' },
+                'var_key',
+                'default_value'
+            )
+            await variableResponse.json()
+        })
 
-                // Some tests require extra params for startup, so we can just create a new test client
-                // for these specific tests.
-                await testClient.createClient({
-                    enableCloudBucketing: true,
-                    enableEdgeDB: true
+        it('should return default if mock server\
+        returns variable mismatching default value type', async () => {
+            scope
+                .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
+                .matchHeader('Content-Type', 'application/json')
+                .matchHeader('authorization', testClient.sdkKey)
+                .reply(200, {
+                    key: 'var_key',
+                    value: 5,
+                    type: 'Number',
+                    isDefaulted: false
                 })
 
+            const variableResponse = await testClient.callVariable(
+                { user_id: 'user1' },
+                'var_key',
+                variablesForTypes['string'].defaultValue
+            )
+            const variable = await variableResponse.json()
+
+            // We can expect that the object we mocked out earlier is going to be
+            // what is returned to us from the proxy server and verify the entityType
+            // is of type "Variable"
+            expect(variable).toEqual(expect.objectContaining({
+                entityType: 'Variable',
+                data: {
+                    key: 'var_key',
+                    value: variablesForTypes['string'].defaultValue,
+                    defaultValue: variablesForTypes['string'].defaultValue,
+                    type: variablesForTypes['string'].type,
+                    isDefaulted: true
+                }
+            }))
+        })
+
+        // Instead of writing tests for each different type we support (String, Boolean, Number, JSON),
+        // this function enumerates each type and runs all tests encapsulated within it to condense repeated tests.
+        forEachVariableType((type) => {
+            it(`should return default ${type} variable if mock server returns undefined`, async () => {
                 scope
                     .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
                     .matchHeader('Content-Type', 'application/json')
                     .matchHeader('authorization', testClient.sdkKey)
-                    .query((queryObj) => {
-                        return !!queryObj.enableEdgeDB
-                    })
-                    .reply(200, {
-                        key: 'var_key',
-                        value: 'value',
-                        defaultValue: 'default_value',
-                        type: 'String',
-                        isDefaulted: false
-                    })
-                const variableResponse = await testClient.callVariable(
-                    { user_id: 'user1' },
-                    'var_key',
-                    'default_value'
-                )
-                await variableResponse.json()
-            })
-
-            it('should return default if mock server\
-            returns variable mismatching default value type', async () => {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
-                    .matchHeader('Content-Type', 'application/json')
-                    .matchHeader('authorization', testClient.sdkKey)
-                    .reply(200, {
-                        key: 'var_key',
-                        value: 5,
-                        type: 'Number',
-                        isDefaulted: false
-                    })
+                    .reply(200, undefined)
 
                 const variableResponse = await testClient.callVariable(
                     { user_id: 'user1' },
                     'var_key',
-                    variablesForTypes['string'].defaultValue
+                    variablesForTypes[type].defaultValue
                 )
                 const variable = await variableResponse.json()
 
-                // We can expect that the object we mocked out earlier is going to be
-                // what is returned to us from the proxy server and verify the entityType
-                // is of type "Variable"
                 expect(variable).toEqual(expect.objectContaining({
                     entityType: 'Variable',
                     data: {
                         key: 'var_key',
-                        value: variablesForTypes['string'].defaultValue,
-                        defaultValue: variablesForTypes['string'].defaultValue,
-                        type: variablesForTypes['string'].type,
+                        value: variablesForTypes[type].defaultValue,
+                        defaultValue: variablesForTypes[type].defaultValue,
+                        type: variablesForTypes[type].type,
                         isDefaulted: true
                     }
                 }))
             })
 
-            // Instead of writing tests for each different type we support (String, Boolean, Number, JSON),
-            // this function enumerates each type and runs all tests encapsulated within it to condense repeated tests.
-            forEachVariableType((type) => {
-                it(`should return default ${type} variable if mock server returns undefined`, async () => {
-                    scope
-                        .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
-                        .matchHeader('Content-Type', 'application/json')
-                        .matchHeader('authorization', testClient.sdkKey)
-                        .reply(200, undefined)
+            it(`should return ${type} variable if mock server returns \
+            proper variable matching default value type`, async () => {
+                scope
+                    .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
+                    .matchHeader('Content-Type', 'application/json')
+                    .matchHeader('authorization', testClient.sdkKey)
+                    .reply(200, variablesForTypes[type])
 
-                    const variableResponse = await testClient.callVariable(
-                        { user_id: 'user1' },
-                        'var_key',
-                        variablesForTypes[type].defaultValue
-                    )
-                    const variable = await variableResponse.json()
+                const variableResponse = await testClient.callVariable(
+                    { user_id: 'user1' },
+                    'var_key',
+                    variablesForTypes[type].defaultValue
+                )
+                const variable = await variableResponse.json()
 
-                    expect(variable).toEqual(expect.objectContaining({
-                        entityType: 'Variable',
-                        data: {
-                            key: 'var_key',
-                            value: variablesForTypes[type].defaultValue,
-                            defaultValue: variablesForTypes[type].defaultValue,
-                            type: variablesForTypes[type].type,
-                            isDefaulted: true
-                        }
-                    }))
-                })
+                expect(variable).toEqual(expect.objectContaining({
+                    entityType: 'Variable',
+                    data: {
+                        key: 'var_key',
+                        value: variablesForTypes[type].value,
+                        defaultValue: variablesForTypes[type].defaultValue,
+                        isDefaulted: false,
+                        type: variablesForTypes[type].type
+                    }
+                }))
+            })
 
-                it(`should return ${type} variable if mock server returns \
-                proper variable matching default value type`, async () => {
-                    scope
-                        .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
-                        .matchHeader('Content-Type', 'application/json')
-                        .matchHeader('authorization', testClient.sdkKey)
-                        .reply(200, variablesForTypes[type])
+            it(`should return defaulted ${type} variable if mock server returns an internal error, \
+            after retrying 5 times`, async () => {
+                scope
+                    .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
+                    .matchHeader('Content-Type', 'application/json')
+                    .matchHeader('authorization', testClient.sdkKey)
+                    // SDK retries the request 5 times + 1 initial request
+                    .times(6)
+                    .reply(500)
 
-                    const variableResponse = await testClient.callVariable(
-                        { user_id: 'user1' },
-                        'var_key',
-                        variablesForTypes[type].defaultValue
-                    )
-                    const variable = await variableResponse.json()
+                const variableResponse = await testClient.callVariable(
+                    { user_id: 'user1' },
+                    'var_key',
+                    variablesForTypes[type].defaultValue
+                )
+                const variable = await variableResponse.json()
 
-                    expect(variable).toEqual(expect.objectContaining({
-                        entityType: 'Variable',
-                        data: {
-                            key: 'var_key',
-                            value: variablesForTypes[type].value,
-                            defaultValue: variablesForTypes[type].defaultValue,
-                            isDefaulted: false,
-                            type: variablesForTypes[type].type
-                        }
-                    }))
-                })
-
-                it(`should return defaulted ${type} variable if mock server returns an internal error, \
-                after retrying 5 times`, async () => {
-                    scope
-                        .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
-                        .matchHeader('Content-Type', 'application/json')
-                        .matchHeader('authorization', testClient.sdkKey)
-                        // SDK retries the request 5 times + 1 initial request
-                        .times(6)
-                        .reply(500)
-
-                    const variableResponse = await testClient.callVariable(
-                        { user_id: 'user1' },
-                        'var_key',
-                        variablesForTypes[type].defaultValue
-                    )
-                    const variable = await variableResponse.json()
-
-                    expect(variable).toEqual(expect.objectContaining({
-                        entityType: 'Variable',
-                        data: {
-                            key: 'var_key',
-                            value: variablesForTypes[type].defaultValue,
-                            isDefaulted: true,
-                            defaultValue: variablesForTypes[type].defaultValue,
-                            type: variablesForTypes[type].type
-                        }
-                    }))
-                })
+                expect(variable).toEqual(expect.objectContaining({
+                    entityType: 'Variable',
+                    data: {
+                        key: 'var_key',
+                        value: variablesForTypes[type].defaultValue,
+                        isDefaulted: true,
+                        defaultValue: variablesForTypes[type].defaultValue,
+                        type: variablesForTypes[type].type
+                    }
+                }))
             })
         })
     })

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -1,20 +1,16 @@
 import {
     describeCapability,
-    forEachSDK,
     forEachVariableType,
     getPlatformBySdkName,
+    getSDKScope,
     hasCapability,
     LocalTestClient,
     waitForRequest
 } from '../helpers'
 import { Capabilities } from '../types'
-import { getServerScope } from '../nock'
 import { config } from '../mockData'
 import { VariableType } from '@devcycle/types'
 import { optionalEventFields, optionalUserEventFields } from '../mockData/events'
-
-// This is our proxy scope that is used to mock endpoints that are called in the SDK
-const scope = getServerScope()
 
 const expectedVariablesByType = {
     // these should match the config in mockData
@@ -52,314 +48,314 @@ const bucketedEventMetadata = {
 }
 
 describe('Variable Tests - Local', () => {
-    // This helper method enumerates all the SDKs and calls each test suite
-    // for each SDK, and creates a test client from the name.
+    // This helper method fetches the current SDK we are testing for the current jest project (see jest.config.js).
     // All supported SDKs can be found under harness/types/sdks.ts
-    forEachSDK((name) => {
-        const expectedPlatform = getPlatformBySdkName(name, true)
+    // it also returns our proxy scope that is used to mock endpoints that are called in the SDK.
+    const { sdkName, scope } = getSDKScope()
 
-        // This describeCapability only runs if the SDK has the "local" capability.
-        // Capabilities are located under harness/types/capabilities and follow the same
-        // name mapping from the sdks.ts file under harness/types/sdks.ts
-        describeCapability(name, Capabilities.local)(name, () => {
-            let testClient: LocalTestClient
-            let eventsUrl: string
+    const expectedPlatform = getPlatformBySdkName(sdkName, true)
 
-            describe('initialized client', () => {
-                beforeEach(async () => {
-                    testClient = new LocalTestClient(name)
-                    // This allows us to mock out the our specific client (using the clientId),
-                    // allowing us to have multiple clients serving different clients without
-                    // conflicting. This one is used to mock the config that the local client is going to use
-                    // locally in all of its methods.
-                    scope
-                        .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
-                        .reply(200, config)
+    // This describeCapability only runs if the SDK has the "local" capability.
+    // Capabilities are located under harness/types/capabilities and follow the same
+    // name mapping from the sdks.ts file under harness/types/sdks.ts
+    describeCapability(sdkName, Capabilities.local)(sdkName, () => {
+        let testClient: LocalTestClient
+        let eventsUrl: string
 
-                    // Creating a client will pass to the proxy server by default:
-                    // - sdk key based on the client id created when creating the client
-                    // - urls for the bucketing/config/events endpoints to redirect traffic
-                    // into the proxy server so nock can mock out the responses
-                    //, or should expect it to error out
-                    // also it sets the client location which can be used
-                    // to access the client instance on the proxy server so we can
-                    // refer to the correct instance from multiple client instances
-                    // the waitForInitialization param is used to wait for the config
-                    // to come back on the proxy server before resolving this promise
-                    await testClient.createClient(true, {
-                        configPollingIntervalMS: 100000,
-                        eventFlushIntervalMS: 500,
-                    })
+        describe('initialized client', () => {
+            beforeEach(async () => {
+                testClient = new LocalTestClient(sdkName)
+                // This allows us to mock out the our specific client (using the clientId),
+                // allowing us to have multiple clients serving different clients without
+                // conflicting. This one is used to mock the config that the local client is going to use
+                // locally in all of its methods.
+                scope
+                    .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                    .reply(200, config)
 
-                    eventsUrl = `/client/${testClient.clientId}/v1/events/batch`
+                // Creating a client will pass to the proxy server by default:
+                // - sdk key based on the client id created when creating the client
+                // - urls for the bucketing/config/events endpoints to redirect traffic
+                // into the proxy server so nock can mock out the responses
+                //, or should expect it to error out
+                // also it sets the client location which can be used
+                // to access the client instance on the proxy server so we can
+                // refer to the correct instance from multiple client instances
+                // the waitForInitialization param is used to wait for the config
+                // to come back on the proxy server before resolving this promise
+                await testClient.createClient(true, {
+                    configPollingIntervalMS: 100000,
+                    eventFlushIntervalMS: 500,
                 })
 
-                // Instead of writing tests for each different type we support (String, Boolean, Number, JSON),
-                // this function enumerates each type and runs all tests encapsulated within it
-                // to condense repeated tests.
-                forEachVariableType((type) => {
-                    const { key, defaultValue, variationOn, variableType } = expectedVariablesByType[type]
+                eventsUrl = `/client/${testClient.clientId}/v1/events/batch`
+            })
 
-                    it('should return variable if mock server returns object matching default type', async () => {
-                        const eventResult = interceptEvents(name, eventsUrl)
+            // Instead of writing tests for each different type we support (String, Boolean, Number, JSON),
+            // this function enumerates each type and runs all tests encapsulated within it
+            // to condense repeated tests.
+            forEachVariableType((type) => {
+                const { key, defaultValue, variationOn, variableType } = expectedVariablesByType[type]
 
-                        const variableResponse = await testClient.callVariable(
-                            { user_id: 'user1', customData: { 'should-bucket': true } },
-                            key,
-                            defaultValue
-                        )
-                        const variable = await variableResponse.json()
-
-                        // Expect that the variable returned is not defaulted and has a value,
-                        // with an entity type "Variable"
-                        expect(variable).toEqual(expect.objectContaining({
-                            entityType: 'Variable',
-                            data: {
-                                type: variableType,
-                                isDefaulted: false,
-                                key,
-                                defaultValue: defaultValue,
-                                value: variationOn,
-                                evalReason: expect.toBeNil()
-                            }
-                        }))
-
-                        if (!hasCapability(name, Capabilities.events)) {
-                            return
-                        }
-
-                        // waits for the request to the events API
-                        await eventResult.wait()
-
-                        // Expect that the SDK sends an "aggVariableEvaluated" event
-                        // for the variable call
-                        expectEventBody(eventResult.body, key, 'aggVariableEvaluated')
-                    })
-
-                    it('should return default value if default type doesn\'t match variable type',  async () => {
-                        const eventResult = interceptEvents(name, eventsUrl)
-
-                        const wrongTypeDefault = type === 'number' ? '1' : 1
-                        const variableResponse =
-                            await testClient.callVariable(
-                                { user_id: 'user1', customData: { 'should-bucket': true } },
-                                key,
-                                wrongTypeDefault
-                            )
-                        const variable = await variableResponse.json()
-
-                        // Expect that the test returns a defaulted variable
-                        expectDefaultValue(key, variable, wrongTypeDefault,
-                            wrongTypeDefault === '1' ? VariableType.string : VariableType.number)
-
-                        if (!hasCapability(name, Capabilities.events)) {
-                            return
-                        }
-
-                        await eventResult.wait()
-
-                        // Expects that the SDK sends an "aggVariableDefaulted" event for the
-                        // defaulted variable
-                        expectEventBody(eventResult.body, key, 'aggVariableDefaulted')
-                    })
-
-                    it('should return default value if user is not bucketed into variable',  async () => {
-                        const eventResult = interceptEvents(name, eventsUrl)
-                        const variableResponse = await testClient.callVariable(
-                            { user_id: 'user3' },
-                            key,
-                            defaultValue
-                        )
-                        const variable = await variableResponse.json()
-
-                        expectDefaultValue(key, variable, defaultValue, variableType)
-
-                        if (!hasCapability(name, Capabilities.events)) {
-                            return
-                        }
-
-                        await eventResult.wait()
-
-                        expectEventBody(eventResult.body, key, 'aggVariableDefaulted')
-                    })
-
-                    it('should return default value if variable doesn\'t exist',  async () => {
-                        const eventResult = interceptEvents(name, eventsUrl)
-
-                        const variableResponse = await testClient.callVariable(
-                            { user_id: 'user1', customData: { 'should-bucket': true } },
-                            'nonexistent',
-                            defaultValue
-                        )
-                        const variable = await variableResponse.json()
-
-                        expectDefaultValue('nonexistent', variable, defaultValue, variableType)
-
-                        if (!hasCapability(name, Capabilities.events)) {
-                            return
-                        }
-
-                        await eventResult.wait()
-
-                        expectEventBody(eventResult.body, 'nonexistent', 'aggVariableDefaulted')
-                    })
-
-                    it('should aggregate aggVariableDefaulted events',  async () => {
-                        const eventResult = interceptEvents(name, eventsUrl)
-
-                        await testClient.callVariable(
-                            { user_id: 'user1', customData: { 'should-bucket': true } },
-                            'nonexistent',
-                            defaultValue
-                        )
-                        await testClient.callVariable(
-                            { user_id: 'user1', customData: { 'should-bucket': true } },
-                            'nonexistent',
-                            defaultValue
-                        )
-
-                        if (!hasCapability(name, Capabilities.events)) {
-                            return
-                        }
-
-                        await eventResult.wait()
-                        expectEventBody(eventResult.body, 'nonexistent', 'aggVariableDefaulted', 2)
-                    })
-
-                    it('should aggregate aggVariableEvaluated events',  async () => {
-                        const eventResult = interceptEvents(name, eventsUrl)
-
-                        await testClient.callVariable(
-                            { user_id: 'user1', customData: { 'should-bucket': true } },
-                            key,
-                            defaultValue
-                        )
-                        await testClient.callVariable(
-                            { user_id: 'user1', customData: { 'should-bucket': true } },
-                            key,
-                            defaultValue
-                        )
-
-                        if (!hasCapability(name, Capabilities.events)) {
-                            return
-                        }
-                        await eventResult.wait()
-                        expectEventBody(eventResult.body, key, 'aggVariableEvaluated', 2)
-                    })
-                })
-
-                it('should return a valid unicode string',  async () => {
-                    const eventResult = interceptEvents(name, eventsUrl)
+                it('should return variable if mock server returns object matching default type', async () => {
+                    const eventResult = interceptEvents(sdkName, eventsUrl)
 
                     const variableResponse = await testClient.callVariable(
                         { user_id: 'user1', customData: { 'should-bucket': true } },
-                        'unicode-var',
-                        'default'
+                        key,
+                        defaultValue
                     )
                     const variable = await variableResponse.json()
 
+                    // Expect that the variable returned is not defaulted and has a value,
+                    // with an entity type "Variable"
                     expect(variable).toEqual(expect.objectContaining({
                         entityType: 'Variable',
                         data: {
-                            type: VariableType.string,
+                            type: variableType,
                             isDefaulted: false,
-                            key: 'unicode-var',
-                            defaultValue: 'default',
-                            value: '↑↑↓↓←→←→BA 🤖',
+                            key,
+                            defaultValue: defaultValue,
+                            value: variationOn,
                             evalReason: expect.toBeNil()
-                        },
-                        logs: []
+                        }
                     }))
 
-                    if (!hasCapability(name, Capabilities.events)) {
+                    if (!hasCapability(sdkName, Capabilities.events)) {
                         return
                     }
 
-                        await eventResult.wait()
-                    expectEventBody(eventResult.body, 'unicode-var', 'aggVariableEvaluated', 1)
+                    // waits for the request to the events API
+                    await eventResult.wait()
+
+                    // Expect that the SDK sends an "aggVariableEvaluated" event
+                    // for the variable call
+                    expectEventBody(eventResult.body, key, 'aggVariableEvaluated')
+                })
+
+                it('should return default value if default type doesn\'t match variable type',  async () => {
+                    const eventResult = interceptEvents(sdkName, eventsUrl)
+
+                    const wrongTypeDefault = type === 'number' ? '1' : 1
+                    const variableResponse =
+                        await testClient.callVariable(
+                            { user_id: 'user1', customData: { 'should-bucket': true } },
+                            key,
+                            wrongTypeDefault
+                        )
+                    const variable = await variableResponse.json()
+
+                    // Expect that the test returns a defaulted variable
+                    expectDefaultValue(key, variable, wrongTypeDefault,
+                        wrongTypeDefault === '1' ? VariableType.string : VariableType.number)
+
+                    if (!hasCapability(sdkName, Capabilities.events)) {
+                        return
+                    }
+
+                    await eventResult.wait()
+
+                    // Expects that the SDK sends an "aggVariableDefaulted" event for the
+                    // defaulted variable
+                    expectEventBody(eventResult.body, key, 'aggVariableDefaulted')
+                })
+
+                it('should return default value if user is not bucketed into variable',  async () => {
+                    const eventResult = interceptEvents(sdkName, eventsUrl)
+                    const variableResponse = await testClient.callVariable(
+                        { user_id: 'user3' },
+                        key,
+                        defaultValue
+                    )
+                    const variable = await variableResponse.json()
+
+                    expectDefaultValue(key, variable, defaultValue, variableType)
+
+                    if (!hasCapability(sdkName, Capabilities.events)) {
+                        return
+                    }
+
+                    await eventResult.wait()
+
+                    expectEventBody(eventResult.body, key, 'aggVariableDefaulted')
+                })
+
+                it('should return default value if variable doesn\'t exist',  async () => {
+                    const eventResult = interceptEvents(sdkName, eventsUrl)
+
+                    const variableResponse = await testClient.callVariable(
+                        { user_id: 'user1', customData: { 'should-bucket': true } },
+                        'nonexistent',
+                        defaultValue
+                    )
+                    const variable = await variableResponse.json()
+
+                    expectDefaultValue('nonexistent', variable, defaultValue, variableType)
+
+                    if (!hasCapability(sdkName, Capabilities.events)) {
+                        return
+                    }
+
+                    await eventResult.wait()
+
+                    expectEventBody(eventResult.body, 'nonexistent', 'aggVariableDefaulted')
+                })
+
+                it('should aggregate aggVariableDefaulted events',  async () => {
+                    const eventResult = interceptEvents(sdkName, eventsUrl)
+
+                    await testClient.callVariable(
+                        { user_id: 'user1', customData: { 'should-bucket': true } },
+                        'nonexistent',
+                        defaultValue
+                    )
+                    await testClient.callVariable(
+                        { user_id: 'user1', customData: { 'should-bucket': true } },
+                        'nonexistent',
+                        defaultValue
+                    )
+
+                    if (!hasCapability(sdkName, Capabilities.events)) {
+                        return
+                    }
+
+                    await eventResult.wait()
+                    expectEventBody(eventResult.body, 'nonexistent', 'aggVariableDefaulted', 2)
+                })
+
+                it('should aggregate aggVariableEvaluated events',  async () => {
+                    const eventResult = interceptEvents(sdkName, eventsUrl)
+
+                    await testClient.callVariable(
+                        { user_id: 'user1', customData: { 'should-bucket': true } },
+                        key,
+                        defaultValue
+                    )
+                    await testClient.callVariable(
+                        { user_id: 'user1', customData: { 'should-bucket': true } },
+                        key,
+                        defaultValue
+                    )
+
+                    if (!hasCapability(sdkName, Capabilities.events)) {
+                        return
+                    }
+                    await eventResult.wait()
+                    expectEventBody(eventResult.body, key, 'aggVariableEvaluated', 2)
                 })
             })
 
-            describe('uninitialized client', () => {
-                let testClient: LocalTestClient
+            it('should return a valid unicode string',  async () => {
+                const eventResult = interceptEvents(sdkName, eventsUrl)
 
-                beforeEach(async () => {
+                const variableResponse = await testClient.callVariable(
+                    { user_id: 'user1', customData: { 'should-bucket': true } },
+                    'unicode-var',
+                    'default'
+                )
+                const variable = await variableResponse.json()
 
+                expect(variable).toEqual(expect.objectContaining({
+                    entityType: 'Variable',
+                    data: {
+                        type: VariableType.string,
+                        isDefaulted: false,
+                        key: 'unicode-var',
+                        defaultValue: 'default',
+                        value: '↑↑↓↓←→←→BA 🤖',
+                        evalReason: expect.toBeNil()
+                    },
+                    logs: []
+                }))
+
+                if (!hasCapability(sdkName, Capabilities.events)) {
+                    return
+                }
+
+                await eventResult.wait()
+                expectEventBody(eventResult.body, 'unicode-var', 'aggVariableEvaluated', 1)
+            })
+        })
+
+        describe('uninitialized client', () => {
+            let testClient: LocalTestClient
+
+            beforeEach(async () => {
+
+            })
+
+            forEachVariableType((type) => {
+                const { key, defaultValue, variableType } = expectedVariablesByType[type]
+
+                it('should return default value if client is uninitialized, log event',  async () => {
+                    testClient = new LocalTestClient(sdkName)
+                    const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
+                    scope
+                        .get(configRequestUrl)
+                        .delay(2000)
+                        .reply(200)
+
+                    eventsUrl = `/client/${testClient.clientId}/v1/events/batch`
+
+                    // A special option is passed in to prevent the proxy server from waiting
+                    // for the client to have a config for the purposes of this uninitialized test suite
+                    // (The call to the proxy server is still awaited)
+                    await testClient.createClient(false, {
+                        eventFlushIntervalMS: 500
+                    })
+
+                    const eventResult = interceptEvents(sdkName, eventsUrl)
+
+                    const variableResponse = await testClient.callVariable(
+                        { user_id: 'user1', customData: { 'should-bucket': true } },
+                        key,
+                        defaultValue
+                    )
+                    const variable = await variableResponse.json()
+                    expectDefaultValue(key, variable, defaultValue, variableType)
+
+                    if (!hasCapability(sdkName, Capabilities.events)) {
+                        return
+                    }
+
+                    await eventResult.wait()
+                    expectEventBody(eventResult.body, key, 'aggVariableDefaulted', 1)
                 })
 
-                forEachVariableType((type) => {
-                    const { key, defaultValue, variableType } = expectedVariablesByType[type]
+                it('should return default value if client config failed, log event',  async () => {
+                    testClient = new LocalTestClient(sdkName)
+                    const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
+                    scope
+                        .get(configRequestUrl)
+                        // account for the immediate retry of the request
+                        .times(2)
+                        .reply(500)
 
-                    it('should return default value if client is uninitialized, log event',  async () => {
-                        testClient = new LocalTestClient(name)
-                        const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
-                        scope
-                            .get(configRequestUrl)
-                            .delay(2000)
-                            .reply(200)
+                    eventsUrl = `/client/${testClient.clientId}/v1/events/batch`
 
-                        eventsUrl = `/client/${testClient.clientId}/v1/events/batch`
-
-                        // A special option is passed in to prevent the proxy server from waiting
-                        // for the client to have a config for the purposes of this uninitialized test suite
-                        // (The call to the proxy server is still awaited)
-                        await testClient.createClient(false, {
-                            eventFlushIntervalMS: 500
-                        })
-
-                        const eventResult = interceptEvents(name, eventsUrl)
-
-                        const variableResponse = await testClient.callVariable(
-                            { user_id: 'user1', customData: { 'should-bucket': true } },
-                            key,
-                            defaultValue
-                        )
-                        const variable = await variableResponse.json()
-                        expectDefaultValue(key, variable, defaultValue, variableType)
-
-                        if (!hasCapability(name, Capabilities.events)) {
-                            return
-                        }
-
-                        await eventResult.wait()
-                        expectEventBody(eventResult.body, key, 'aggVariableDefaulted', 1)
+                    // A special option is passed in to prevent the proxy server from waiting
+                    // for the client to have a config for the purposes of this uninitialized test suite
+                    // (The call to the proxy server is still awaited)
+                    await testClient.createClient(false, {
+                        eventFlushIntervalMS: 500
                     })
 
-                    it('should return default value if client config failed, log event',  async () => {
-                        testClient = new LocalTestClient(name)
-                        const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
-                        scope
-                            .get(configRequestUrl)
-                            // account for the immediate retry of the request
-                            .times(2)
-                            .reply(500)
+                    const eventResult = interceptEvents(sdkName, eventsUrl)
 
-                        eventsUrl = `/client/${testClient.clientId}/v1/events/batch`
+                    const variableResponse = await testClient.callVariable(
+                        { user_id: 'user1', customData: { 'should-bucket': true } },
+                        key,
+                        defaultValue
+                    )
+                    const variable = await variableResponse.json()
+                    expectDefaultValue(key, variable, defaultValue, variableType)
 
-                        // A special option is passed in to prevent the proxy server from waiting
-                        // for the client to have a config for the purposes of this uninitialized test suite
-                        // (The call to the proxy server is still awaited)
-                        await testClient.createClient(false, {
-                            eventFlushIntervalMS: 500
-                        })
+                    if (!hasCapability(sdkName, Capabilities.events)) {
+                        return
+                    }
 
-                        const eventResult = interceptEvents(name, eventsUrl)
-
-                        const variableResponse = await testClient.callVariable(
-                            { user_id: 'user1', customData: { 'should-bucket': true } },
-                            key,
-                            defaultValue
-                        )
-                        const variable = await variableResponse.json()
-                        expectDefaultValue(key, variable, defaultValue, variableType)
-
-                        if (!hasCapability(name, Capabilities.events)) {
-                            return
-                        }
-
-                        await eventResult.wait()
-                        expectEventBody(eventResult.body, key, 'aggVariableDefaulted', 1)
-                    })
+                    await eventResult.wait()
+                    expectEventBody(eventResult.body, key, 'aggVariableDefaulted', 1)
                 })
             })
         })

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -22,7 +22,6 @@ export const getMockServerUrl = () => {
     return `http://${process.env.DOCKER_HOST_IP ?? 'host.docker.internal'}:${global.__MOCK_SERVER_PORT__}`
 }
 
-
 export const getConnectionStringForProxy = (proxy: string) => {
     if (process.env.LOCAL_MODE === "1") {
         return `http://localhost:3000`
@@ -45,7 +44,7 @@ const clientTestNameMap: Record<string, string> = {}
 // It can be formatted as a JSON array or a comma-separated list.
 // The SDKs are returned as their human-readable names from the Sdks enum, not the enum keys.
 export const getSDKs = () => {
-    const SDKS_TO_TEST = process.env.SDKS_TO_TEST || global.JEST_PROJECT_SDK_TO_TEST
+    const SDKS_TO_TEST = process.env.SDKS_TO_TEST
 
     try {
         return JSON.parse(SDKS_TO_TEST ?? '').map((sdk) => Sdks[sdk])
@@ -63,30 +62,31 @@ export const getSDKs = () => {
     }
 }
 
-export const forEachSDK = (tests) => {
-    const SDKs = getSDKs()
+/**
+ * This is used within the jest tests to fetch the running SDK environment for the current jest project.
+ * See `jest.config.ts` for more details on all projects. We also use this function to get the current nock server scope
+ * and add an `afterEach()` method to cleanup the client.
+ */
+export const getSDKScope = (): { sdkName: string, scope: Scope } => {
+    const sdkName = global.JEST_PROJECT_SDK_TO_TEST
+    if (!sdkName) {
+        throw new Error('No SDK specified to test using global.JEST_PROJECT_SDK_TO_TEST in jest.config.ts')
+    }
     const scope = getServerScope()
 
-    if (process.env.SDKS_TO_TEST && global.JEST_PROJECT_SDK_TO_TEST && process.env.SDKS_TO_TEST !== global.JEST_PROJECT_SDK_TO_TEST) {
-        // environment has overriden the SDKs we want to test, this Jest project should skip all tests
-        SDKs = []
-    }
+    afterEach(async () => {
+        await currentClient.close()
 
-    describe.each(SDKs)('%s SDK tests', (name) => {
-        afterEach(async () => {
-            await currentClient.close()
-
-            if (!scope.isDone()) {
-                const pendingMocks = scope.pendingMocks()
-                resetServerScope()
-                throw new Error('Requests were expected but not received: ' + pendingMocks)
-            }
-
+        if (!scope.isDone()) {
+            const pendingMocks = scope.pendingMocks()
             resetServerScope()
-            await global.assertNoUnmatchedRequests(currentClient.clientId, clientTestNameMap)
-        })
-        tests(name)
+            throw new Error('Requests were expected but not received: ' + pendingMocks)
+        }
+
+        resetServerScope()
+        await global.assertNoUnmatchedRequests(currentClient.clientId, clientTestNameMap)
     })
+    return { sdkName, scope }
 }
 
 export const describeIf = (condition: boolean) => condition ? describe : describe.skip

--- a/harness/types/sdks.ts
+++ b/harness/types/sdks.ts
@@ -7,5 +7,5 @@ export const Sdks = {
     // TODO uncomment once Java is ready
     // java: 'Java'
     // TODO add once python is ready
-    // python: "Python"
+    // python: 'Python'
 }

--- a/jest-global.ts
+++ b/jest-global.ts
@@ -1,6 +1,4 @@
-import {
-    getSDKs
-} from './harness/helpers'
+import { getSDKs } from './harness/helpers'
 import testContainersSetup from '@trendyol/jest-testcontainers/dist/setup'
 
 async function setup(opts) {
@@ -10,7 +8,7 @@ async function setup(opts) {
 
     // COMPOSE_PROFILES controls which docker-compose services are run via their profiles setting in docker-compose.yml
     process.env.COMPOSE_PROFILES = sdks.map((sdkName: string) => sdkName.toLowerCase()).join(',')
-    
+
     if (process.env.LOCAL_MODE === '1') {
         // Effectively disable all docker containers by setting a profile that none of them use
         process.env.COMPOSE_PROFILES = 'local'

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,3 +1,3 @@
 // add all jest-extended matchers
 const matchers = require('jest-extended')
-expect.extend(matchers);
+expect.extend(matchers)

--- a/jest-testcontainers-config.js
+++ b/jest-testcontainers-config.js
@@ -1,7 +1,7 @@
 module.exports = {
     dockerCompose: {
-        composeFilePath: ".",
-        composeFile: "docker-compose.yml",
+        composeFilePath: '.',
+        composeFile: 'docker-compose.yml',
         startupTimeout: 20000,
     }
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,3 +1,5 @@
+import { getSDKs } from './harness/helpers'
+
 const commonConfig = {
     preset: '@trendyol/jest-testcontainers',
     transform: {
@@ -8,23 +10,49 @@ const commonConfig = {
     setupFilesAfterEnv: ['./jest-setup.js'],
 }
 
+const projects = [
+    {
+        ...commonConfig,
+        displayName: 'NodeJS',
+        globals: {
+            JEST_PROJECT_SDK_TO_TEST: 'NodeJS',
+        }
+    },
+    {
+        ...commonConfig,
+        displayName: 'DotNet',
+        globals: {
+            JEST_PROJECT_SDK_TO_TEST: 'DotNet',
+        }
+    },
+    {
+        ...commonConfig,
+        displayName: 'Go',
+        globals: {
+            JEST_PROJECT_SDK_TO_TEST: 'Go',
+        }
+    },
+    {
+        ...commonConfig,
+        displayName: 'GoNative',
+        globals: {
+            JEST_PROJECT_SDK_TO_TEST: 'GoNative',
+        }
+    },
+    {
+        ...commonConfig,
+        displayName: 'Ruby',
+        globals: {
+            JEST_PROJECT_SDK_TO_TEST: 'Ruby',
+        }
+    },
+]
+const SDKs = getSDKs().map((sdkName) => sdkName.toLowerCase())
+const filteredProjects = projects.filter((project) => SDKs.includes(project.displayName.toLowerCase()))
+console.log(`Running jest tests for SDKs: ${filteredProjects.map((project) => project.displayName).join(', ')}`)
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     testTimeout: 60000,
-    projects: [
-        {
-            ...commonConfig,
-            displayName: 'NodeJS',
-            globals: {
-                JEST_PROJECT_SDK_TO_TEST: 'nodejs'
-            }
-        },
-        {
-            ...commonConfig,
-            displayName: 'DotNet',
-            globals: {
-                JEST_PROJECT_SDK_TO_TEST: 'dotnet'
-            }
-        },
-    ]
+    projects: filteredProjects
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,4 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
+const commonConfig = {
     preset: '@trendyol/jest-testcontainers',
     transform: {
         '^.+\\.tsx?$': ['ts-jest', {}]
@@ -7,5 +6,25 @@ module.exports = {
     globalSetup: './jest-global.ts',
     testEnvironment: './jest-environment.ts',
     setupFilesAfterEnv: ['./jest-setup.js'],
+}
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
     testTimeout: 60000,
+    projects: [
+        {
+            ...commonConfig,
+            displayName: 'NodeJS',
+            globals: {
+                JEST_PROJECT_SDK_TO_TEST: 'nodejs'
+            }
+        },
+        {
+            ...commonConfig,
+            displayName: 'DotNet',
+            globals: {
+                JEST_PROJECT_SDK_TO_TEST: 'dotnet'
+            }
+        },
+    ]
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -46,6 +46,22 @@ const projects = [
             JEST_PROJECT_SDK_TO_TEST: 'Ruby',
         }
     },
+    // TODO uncomment once Java is ready
+    // {
+    //     ...commonConfig,
+    //     displayName: 'Java',
+    //     globals: {
+    //         JEST_PROJECT_SDK_TO_TEST: 'Java',
+    //     }
+    // },
+    // TODO uncomment once Python is ready
+    // {
+    //     ...commonConfig,
+    //     displayName: 'Python',
+    //     globals: {
+    //         JEST_PROJECT_SDK_TO_TEST: 'Python',
+    //     }
+    // },
 ]
 const SDKs = getSDKs().map((sdkName) => sdkName.toLowerCase())
 const filteredProjects = projects.filter((project) => SDKs.includes(project.displayName.toLowerCase()))


### PR DESCRIPTION
Switch from running tests for each SDK using `describe.each` to using Jest "projects" which each define the SDK that should be tested.

TODO: figure out how to compartmentalize the docker compose files for each project to only run the appropriate proxy container.