### PR TITLE
chore: added a guide.md to prescribe how to write test harness tests

### DIFF
--- a/docs/GUIDE.MD
+++ b/docs/GUIDE.MD
@@ -1,0 +1,54 @@
+# How To Write Test Harness Tests
+
+_Refer to the Variable Cloud tests and Variable Local tests on how to write tests for both Cloud and Local bucketing._
+
+![Architecture overview of the test harness](https://user-images.githubusercontent.com/10345366/211103174-93507d88-814f-4177-bbb3-392830e6a280.png)
+
+The test harness is built using `jest-testcontainers` which can run docker containers that can be used in our tests. The test harness uses it to spin up
+proxy servers, written in the language they are meant to test.The `docker-compose.yml` file lists the images that are to be spun up when the tests start up.
+There is also `jest-environment.ts` where some globals are set up and where the mock API server is setup and torn down.
+
+The tests send commands to the proxy server through http requests, the spec of which you can find at `docs/spec.yaml`. The proxy server then calls the SDK based on the request from the test harness and will respond back with the results to the test harness. The SDK is also configured by the test harness to point all API calls to the mock server using `nock`; the proxy server initializes the SDK with options that change the base URL to the urls passed by the proxy server. This allows us to mock API calls from the SDK.
+
+Tests are divided into separate features that are present in each SDK tested by the test harness. The tests are located under
+`harness/features/`. There are also helper methods located under `harness/helpers.ts` that can be used to create SDK clients, call certain
+features on the proxy server and return the response, etc.
+
+An important helper method is the `forEachSDK` helper method, which can be wrapped around any tests to run the tests for all SDKs listed under
+`harness/types/sdks.ts`.
+
+Another useful method is to wrap tests with a `describeCapability` function, passing in a capability listed under `harness/types/capabilities.ts`. 
+This is used to segment different SDKs with different tests that are present on some SDKs but not all, e.g. Python not having a local bucketing capability.
+
+Lastly, we use `nock` to mock out server responses sent from the SDK. This allows to stub out certain methods on different URLs and return data objects.
+
+```
+e.g. This stubs out any calls from the SDK for the /variables endpoint with the specific variable key "var_key" and returns a variable object.
+
+Note: we can also granularly match on query params, this example matches on if the "enableEdgeDb" query param is set.
+Note: If you create a mock using nock, it will fail if that URL was not called at all
+scope
+    .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
+    .matchHeader('Content-Type', 'application/json')
+    .matchHeader('authorization', testClient.sdkKey)
+    .query((queryObj) => {
+        return !!queryObj.enableEdgeDB
+    })
+    .reply(200, {
+        key: 'var_key',
+        value: 'value',
+        defaultValue: 'default_value',
+        type: 'String',
+        isDefaulted: false
+    })
+```
+
+We can then use our helper methods to call the `variable` method on our proxy servers: 
+```
+const variableResponse = await testClient.callVariable(
+    { user_id: 'user1' },
+    'var_key',
+    'default_value'
+)
+const response = await variableResponse()
+```

--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -1,27 +1,41 @@
 import {
     forEachSDK,
-    describeIf,
     forEachVariableType,
     variablesForTypes,
     CloudTestClient, describeCapability, expectErrorMessageToBe
 } from '../helpers'
-import { Capabilities, SDKCapabilities } from '../types'
+import { Capabilities } from '../types'
 import { getServerScope } from '../nock'
 
+// This is our proxy scope that is used to mock endpoints that are called in the SDK
 const scope = getServerScope()
 
 describe('Variable Tests - Cloud', () => {
+    // This helper method enumerates all the SDKs and calls each test suite
+    // for each SDK, and creates a test client from the name.
+    // All supported SDKs can be found under harness/types/sdks.ts
     forEachSDK((name) => {
         const testClient = new CloudTestClient(name)
 
         beforeAll(async () => {
+            // Creating a client will pass to the proxy server by default: 
+            // - sdk key based on the client id created when creating the client
+            // - urls for the bucketing/config/events endpoints to redirect traffic
+            // into the proxy server so nock can mock out the responses
+            // - options like should wait for initialization, or should 
+            // expect it to error out
             await testClient.createClient({
                 enableCloudBucketing: true
             })
         })
 
+        // This describeCapability only runs if the SDK has the "cloud" capability.
+        // Capabilities are located under harness/types/capabilities and follow the same
+        // name mapping from the sdks.ts file under harness/types/sdks.ts
         describeCapability(name, Capabilities.cloud)(name, () => {
             it('will throw error variable called with invalid key', async () => {
+                // Helper method calls the proxy server to trigger the "variable" method in
+                // the SDK
                 const variableResponse = await testClient.callVariable(
                     { user_id: 'user1' },
                     null,
@@ -29,6 +43,8 @@ describe('Variable Tests - Cloud', () => {
                     true
                 )
                 const error = await variableResponse.json()
+                // Helper method to equate error messages from the error object returned
+                // from the proxy server
                 expectErrorMessageToBe(error.asyncError, 'Missing parameter: key')
             })
 
@@ -45,6 +61,11 @@ describe('Variable Tests - Cloud', () => {
             })
 
             it('should call variables API without edgeDB option', async () => {
+                // This allows us to mock out the our specific client (using the clientId),
+                // allowing us to have multiple mock APIs serving different clients without
+                // conflicting. We can match on specific criteria, like headers and the query params
+                // to specify which call we want to mock, and reply with a status code and an object
+                // as a response
                 scope
                     .post(`/client/${testClient.clientId}/v1/variables/var_key`, (body) => body.user_id === 'user1')
                     .matchHeader('Content-Type', 'application/json')
@@ -70,6 +91,8 @@ describe('Variable Tests - Cloud', () => {
             it('should call variables API with edgeDB option', async () => {
                 const testClient = new CloudTestClient(name)
 
+                // Some tests require extra params for startup, so we can just create a new test client
+                // for these specific tests.
                 await testClient.createClient({
                     enableCloudBucketing: true,
                     enableEdgeDB: true
@@ -95,7 +118,6 @@ describe('Variable Tests - Cloud', () => {
                     'default_value'
                 )
                 await variableResponse.json()
-
             })
 
             it('should return default if mock server\
@@ -118,6 +140,9 @@ describe('Variable Tests - Cloud', () => {
                 )
                 const variable = await variableResponse.json()
 
+                // We can expect that the object we mocked out earlier is going to be 
+                // what is returned to us from the proxy server and verify the entityType
+                // is of type "Variable"
                 expect(variable).toEqual(expect.objectContaining({
                     entityType: 'Variable',
                     data: {
@@ -130,6 +155,8 @@ describe('Variable Tests - Cloud', () => {
                 }))
             })
 
+            // Instead of writing tests for each different type we support (String, Boolean, Number, JSON), 
+            // this function enumerates each type and runs all tests encapsulated within it to condense repeated tests.
             forEachVariableType((type) => {
                 it(`should return default ${type} variable if mock server returns undefined`, async () => {
                     scope


### PR DESCRIPTION
# Summary

Added comments to local and cloud variable tests, along with a `GUIDE.md` to prescribe how to write harness tests.