### PR TITLE
install from github sha for Go proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,3 +45,6 @@ services:
         - GO_SDK_VERSION=${GO_SDK_VERSION}
         - SDK_GITHUB_SHA=${SDK_GITHUB_SHA}
         - SDKS_TO_TEST=${SDKS_TO_TEST}
+    container_name: go
+    ports:
+      - "3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,10 @@ services:
 #    container_name: java
 #    ports:
 #      - "3000"
+  go:
+    build:
+      context: ./proxies/go
+      args:
+        - GO_SDK_VERSION=${GO_SDK_VERSION}
+        - SDK_GITHUB_SHA=${SDK_GITHUB_SHA}
+        - SDKS_TO_TEST=${SDKS_TO_TEST}

--- a/proxies/go/Dockerfile
+++ b/proxies/go/Dockerfile
@@ -1,8 +1,33 @@
-FROM golang:1.16-alpine
+FROM golang:1.16 as builder
+
+ARG GO_SDK_VERSION
+ENV GO_SDK_VERSION $GO_SDK_VERSION
+
+ARG SDK_GITHUB_SHA
+ENV SDK_GITHUB_SHA $SDK_GITHUB_SHA
+
+ARG SDKS_TO_TEST
+ENV SDKS_TO_TEST $SDKS_TO_TEST
+
 WORKDIR /app
 COPY go.mod ./
 COPY go.sum ./
+COPY install.sh ./
+
+RUN ./install.sh
+
 RUN go mod download
 COPY *.go ./
 RUN go build -o /proxy
+
+
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+# Copy the pre-built binary file from the previous stage
+COPY --from=builder /proxy .
+
+EXPOSE 3000
+
 CMD [ "/proxy" ]

--- a/proxies/go/Dockerfile
+++ b/proxies/go/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.16 as builder
+# reference https://github.com/docker-library/golang/issues/209#issuecomment-530591780
+
+FROM golang:1.19 as builder
 
 ARG GO_SDK_VERSION
 ENV GO_SDK_VERSION $GO_SDK_VERSION
@@ -9,6 +11,9 @@ ENV SDK_GITHUB_SHA $SDK_GITHUB_SHA
 ARG SDKS_TO_TEST
 ENV SDKS_TO_TEST $SDKS_TO_TEST
 
+ENV CGO_ENABLED 0
+ENV GOOS linux
+
 WORKDIR /app
 COPY go.mod ./
 COPY go.sum ./
@@ -18,7 +23,7 @@ RUN ./install.sh
 
 RUN go mod download
 COPY *.go ./
-RUN go build -o /proxy
+RUN go build -a -installsuffix cgo -o proxy .
 
 
 FROM alpine:latest
@@ -26,8 +31,8 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 
 # Copy the pre-built binary file from the previous stage
-COPY --from=builder /proxy .
+COPY --from=builder /app/proxy .
 
 EXPOSE 3000
 
-CMD [ "/proxy" ]
+ENTRYPOINT ["./proxy"]

--- a/proxies/go/install.sh
+++ b/proxies/go/install.sh
@@ -1,7 +1,7 @@
 if [ -n "$SDK_GITHUB_SHA" ] && [[ "$SDKS_TO_TEST" =~ .*"go"* ]]; then
-    go get "github.com/DevCycleHQ/go-server-sdk@$SDK_GITHUB_SHA"
+    go get "github.com/devcyclehq/go-server-sdk@$SDK_GITHUB_SHA"
 elif [ -z "$GO_SDK_VERSION" ]; then
-    go get "github.com/DevCycleHQ/go-server-sdk"
+    go get "github.com/devcyclehq/go-server-sdk"
 else
-    go get "github.com/DevCycleHQ/go-server-sdk@$GO_SDK_VERSION"
+    go get "github.com/devcyclehq/go-server-sdk@$GO_SDK_VERSION"
 fi

--- a/proxies/go/install.sh
+++ b/proxies/go/install.sh
@@ -1,0 +1,7 @@
+if [ -n "$SDK_GITHUB_SHA" ] && [[ "$SDKS_TO_TEST" =~ .*"go"* ]]; then
+    go get "github.com/DevCycleHQ/go-server-sdk@$SDK_GITHUB_SHA"
+elif [ -z "$GO_SDK_VERSION" ]; then
+    go get "github.com/DevCycleHQ/go-server-sdk"
+else
+    go get "github.com/DevCycleHQ/go-server-sdk@$GO_SDK_VERSION"
+fi


### PR DESCRIPTION
- install Go from Github sha or specific version
- update dockerfile to use builder image and call the install script
- hook up to docker compose