### PR TITLE
fix serializing variable responses on go

### DIFF
--- a/proxies/go/handler_command.go
+++ b/proxies/go/handler_command.go
@@ -232,6 +232,8 @@ func parseEntity(entityType reflect.Type, result []reflect.Value, err *error) (s
 		if len(features) > 0 {
 			parsedResult = features
 		}
+	} else if entityType == reflect.TypeOf((*devcycle.Variable)(nil)).Elem() {
+		parsedResult = result[0].Interface().(devcycle.Variable)
 	}
 
 	entityName := entityType.Name()


### PR DESCRIPTION
Fix variable serialization by explicitly casting it when we know its a Variable object