### PR TITLE
Dvc 5965 set minimum node version for test harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@devcycle/test-harness",
+  "engines" : { 
+    "node" : ">=18.0.0"
+  },
   "scripts": {
     "test": "jest --verbose",
     "test:ci": "yarn test --setupFiles=./ci-config.ts",


### PR DESCRIPTION
Issue: If running tests with node v16, error is found `ReferenceError: fetch is not defined`
- set minimum node version(v18) for test harness to let tests run properly