### PR TITLE
DVC-6142 client custom data tests

### DIFF
--- a/harness/features/clientCustomData.test.ts
+++ b/harness/features/clientCustomData.test.ts
@@ -1,7 +1,9 @@
 import {
     getConnectionStringForProxy,
     forEachSDK,
-    LocalTestClient, describeCapability, CloudTestClient, waitForRequest
+    LocalTestClient,
+    describeCapability,
+    waitForRequest
 } from '../helpers'
 import { Capabilities } from '../types'
 import { config } from '../mockData'

--- a/harness/features/clientCustomData.test.ts
+++ b/harness/features/clientCustomData.test.ts
@@ -1,0 +1,83 @@
+import {
+    getConnectionStringForProxy,
+    forEachSDK,
+    LocalTestClient, describeCapability, CloudTestClient, waitForRequest
+} from '../helpers'
+import { Capabilities } from '../types'
+import { config } from '../mockData'
+import { getServerScope } from '../nock'
+
+const scope = getServerScope()
+
+describe('Client Custom Data Tests', () => {
+    forEachSDK((name) => {
+        let url: string
+        beforeAll(async () => {
+            url = getConnectionStringForProxy(name)
+        })
+
+        describeCapability(name, Capabilities.clientCustomData)(name, () => {
+            it('should set client custom data and use it for segmentation', async () => {
+                const client = new LocalTestClient(name)
+
+                scope
+                    .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
+                    .reply(200, config)
+
+                scope
+                    .post(`/client/${client.clientId}/v1/events/batch`)
+                    .reply(201)
+
+
+                const customData = { 'should-bucket': true }
+                await client.createClient(true)
+                await client.callSetClientCustomData(customData)
+                const user = { user_id: 'test-user'}
+                const response = await client.callVariable(user, 'string-var', 'some-default')
+                const variable = await response.json()
+                expect(variable).toEqual(expect.objectContaining({
+                    entityType: 'Variable',
+                    data: {
+                        type: 'String',
+                        isDefaulted: false,
+                        key: 'string-var',
+                        defaultValue: 'some-default',
+                        value: 'string'
+                    }
+                }))
+                await client.close()
+            })
+
+            it('should do nothing when client has not initialized', async () => {
+                const client = new LocalTestClient(name)
+                const configCall = scope
+                    .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
+
+                configCall
+                    .delay(1000)
+                    .reply(200, config)
+
+                const customData = { 'should-bucket': true }
+                await client.createClient(false)
+                await client.callSetClientCustomData(customData)
+                await waitForRequest(scope, configCall, 1000, 'Config request timed out')
+
+                const response = await client.callVariable({user: 'user-id'}, 'string-var', 'some-default')
+                const variable = await response.json()
+                expect(variable).toEqual(expect.objectContaining({
+                    entityType: 'Variable',
+                    data: {
+                        type: 'String',
+                        isDefaulted: true,
+                        key: 'string-var',
+                        defaultValue: 'some-default',
+                        value: 'some-default'
+                    }
+                }))
+
+                await client.close()
+            })
+        })
+    })
+})
+

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -359,6 +359,18 @@ export class LocalTestClient extends BaseTestClient {
 
         return result
     }
+
+    async callSetClientCustomData(data: Record<string, unknown>, shouldFail = false) {
+        const result = await sendCommand(this.getClientUrl(), {
+            command: 'setClientCustomData',
+            params: [{ value: data }],
+            isAsync: false
+        })
+
+        await checkFailed(result, shouldFail)
+
+        return result
+    }
 }
 
 export class CloudTestClient extends BaseTestClient {

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -2,7 +2,8 @@ export const Capabilities = {
     edgeDB: 'EdgeDB',
     local: 'LocalBucketing',
     cloud: 'CloudBucketing',
-    sse: 'SSE'
+    sse: 'SSE',
+    clientCustomData: 'ClientCustomData',
 }
 
 export const SDKCapabilities = {
@@ -10,5 +11,5 @@ export const SDKCapabilities = {
     Python: [Capabilities.cloud, Capabilities.edgeDB],
     DotNet: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
     Java: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
-    Go: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
+    Go: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData],
 }

--- a/proxies/go/handler_command.go
+++ b/proxies/go/handler_command.go
@@ -204,6 +204,13 @@ func callMethodOnEntity(
 
 	result := method.Call(params)
 
+	for _, value := range result {
+		if value.Type().Implements(reflect.TypeOf(err).Elem()) && value.Interface() != nil {
+			// panic to catch error in defer function above
+			panic(value.Interface())
+		}
+	}
+
 	entityType := method.Type().Out(0)
 	entityName, parsedResult := parseEntity(entityType, result, err)
 


### PR DESCRIPTION
- add tests for setClientCustomData
- fix Go proxy to respond with error when a method with an error return value sets that value to something