### PR TITLE
DVC-6222 fix initialize SDK tests with new expectErrorToContain()

### DIFF
--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -1,7 +1,7 @@
 import {
     forEachSDK,
     wait,
-    LocalTestClient, describeCapability, expectErrorMessageToBe
+    LocalTestClient, describeCapability, expectErrorMessageToBe, expectErrorToContain
 } from '../helpers'
 import { Capabilities } from '../types'
 import { config, shouldBucketUser } from '../mockData'
@@ -17,9 +17,9 @@ describe('Initialize Tests - Local', () => {
                 const response = await testClient.createClient(true, {}, null, true)
                 const { exception } = await response.json()
 
-                expectErrorMessageToBe(
+                expectErrorToContain(
                     exception,
-                    'Missing environment key! Call initialize with a valid environment key'
+                    ['Missing SDK key! Call ' + ' with a valid SDK key']
                 )
             })
 
@@ -28,9 +28,9 @@ describe('Initialize Tests - Local', () => {
                 const response = await testClient.createClient(true, {}, 'invalid key', true)
                 const { exception } = await response.json()
 
-                expectErrorMessageToBe(
+                expectErrorToContain(
                     exception,
-                    'Invalid environment key provided. Please call initialize with a valid server environment key'
+                    ['Invalid SDK key provided. Please call ' + ' with a valid server SDK key']
                 )
             })
 

--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -19,7 +19,7 @@ describe('Initialize Tests - Local', () => {
 
                 expectErrorToContain(
                     exception,
-                    ['Missing SDK key! Call ' + ' with a valid SDK key']
+                    ['Missing SDK key! Call ', ' with a valid SDK key']
                 )
             })
 
@@ -30,7 +30,7 @@ describe('Initialize Tests - Local', () => {
 
                 expectErrorToContain(
                     exception,
-                    ['Invalid SDK key provided. Please call ' + ' with a valid server SDK key']
+                    ['Invalid SDK key provided. Please call ', ' with a valid server SDK key']
                 )
             })
 

--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -1,7 +1,9 @@
 import {
     forEachSDK,
     wait,
-    LocalTestClient, describeCapability, expectErrorMessageToBe, expectErrorToContain
+    LocalTestClient,
+    describeCapability,
+    expectErrorMessageToBe
 } from '../helpers'
 import { Capabilities } from '../types'
 import { config, shouldBucketUser } from '../mockData'
@@ -17,9 +19,9 @@ describe('Initialize Tests - Local', () => {
                 const response = await testClient.createClient(true, {}, null, true)
                 const { exception } = await response.json()
 
-                expectErrorToContain(
+                expectErrorMessageToBe(
                     exception,
-                    ['Missing SDK key! Call ', ' with a valid SDK key']
+                    'Missing SDK key! Call initialize with a valid SDK key'
                 )
             })
 
@@ -28,9 +30,9 @@ describe('Initialize Tests - Local', () => {
                 const response = await testClient.createClient(true, {}, 'invalid key', true)
                 const { exception } = await response.json()
 
-                expectErrorToContain(
+                expectErrorMessageToBe(
                     exception,
-                    ['Invalid SDK key provided. Please call ', ' with a valid server SDK key']
+                    'Invalid SDK key provided. Please call initialize with a valid server SDK key'
                 )
             })
 

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -442,15 +442,6 @@ export class CloudTestClient extends BaseTestClient {
     }
 }
 
-export const expectErrorToContain = (message: string, expectedStrings: string[]) => {
-    expectedStrings.forEach((expected) => {
-        if (!message.includes(expected)) {
-            console.warn(`Expected error message to contain: \n ${expected}, but got: \n ${message}`)
-        }
-        expect(message).toContain(expected)
-    })
-}
-
 export const expectErrorMessageToBe = (message: string, expected: string) => {
     // when we consolidate error messages to be uniform, change this to actually compare
     // the exception and the expected exception message

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -442,6 +442,15 @@ export class CloudTestClient extends BaseTestClient {
     }
 }
 
+export const expectErrorToContain = (message: string, expectedStrings: string[]) => {
+    expectedStrings.forEach((expected) => {
+        if (!message.includes(expected)) {
+            console.warn(`Expected error message to contain: \n ${expected}, but got: \n ${message}`)
+        }
+        expect(message).toContain(expected)
+    })
+}
+
 export const expectErrorMessageToBe = (message: string, expected: string) => {
     // when we consolidate error messages to be uniform, change this to actually compare
     // the exception and the expected exception message


### PR DESCRIPTION
As some SDKs will log either: 
- `Missing SDK key! Call build with a valid SDK key`
- `Missing SDK key! Call initialize with a valid SDK key`