### PR TITLE
[fix] Return java sdk errors from proxy

### DIFF
--- a/proxies/java/src/main/java/com/dvc_harness/proxy/controller/ProxyController.java
+++ b/proxies/java/src/main/java/com/dvc_harness/proxy/controller/ProxyController.java
@@ -94,13 +94,7 @@ public class ProxyController {
             return new MessageResponse("Invalid request: missing params");
         }
 
-        Object[] parsedParams;
-        try {
-            parsedParams = this.parseParams(body);
-        } catch (Exception e) {
-            response.setStatus(404);
-            return new MessageResponse("Invalid request: missing entity from param");
-        }
+        Object[] parsedParams = this.parseParams(body);
 
         try {
             Object entity = getEntityFromLocation(request.getRequestURI());
@@ -121,7 +115,7 @@ public class ProxyController {
             );
         } catch (Exception e) {
             logger.log(Level.INFO, e.toString());
-            return new ExceptionResponse((Exception) e.getCause());
+            return body.isAsync ? new AsyncErrorResponse(e) : new ExceptionResponse(e);
         }
     }
 
@@ -144,7 +138,7 @@ public class ProxyController {
         return null;
     }
 
-    private Object[] parseParams(LocationRequestBody body) throws Exception {
+    private Object[] parseParams(LocationRequestBody body) {
         Object[] parsedParams = new Object[body.params.length];
         for (int i=0; i < body.params.length; i++) {
             LocationParam element = body.params[i];

--- a/proxies/java/src/main/java/com/dvc_harness/proxy/models/AsyncErrorResponse.java
+++ b/proxies/java/src/main/java/com/dvc_harness/proxy/models/AsyncErrorResponse.java
@@ -2,8 +2,10 @@ package com.dvc_harness.proxy.models;
 
 public class AsyncErrorResponse extends BaseResponse {
     public final String asyncError;
+    public StackTraceElement[] stack;
 
-    public AsyncErrorResponse(String message) {
-        this.asyncError = message;
+    public AsyncErrorResponse(Exception error) {
+        this.asyncError = error.toString();
+        this.stack = error.getStackTrace();
     }
 }

--- a/proxies/java/src/main/java/com/dvc_harness/proxy/models/CommandResult.java
+++ b/proxies/java/src/main/java/com/dvc_harness/proxy/models/CommandResult.java
@@ -1,5 +1,6 @@
 package com.dvc_harness.proxy.models;
 
+import com.devcycle.sdk.server.common.model.User;
 import com.dvc_harness.proxy.data.DataStore;
 
 import java.lang.reflect.InvocationTargetException;
@@ -24,7 +25,7 @@ public class CommandResult<T> {
 
     public CommandResult invokeCommand(
         Object[] params
-    ) throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
+    ) throws NoSuchMethodException, Exception {
         Method[] allEntityMethods = this.entity.getClass().getMethods();
         Method methodToExecute = null;
         for(int i = 0; i < allEntityMethods.length; i++) {
@@ -36,7 +37,11 @@ public class CommandResult<T> {
         if (methodToExecute == null) {
             throw new NoSuchMethodException();
         }
-        this.body = methodToExecute.invoke(this.entity, params);
+        try {
+            this.body = methodToExecute.invoke(this.entity, params);
+        } catch (Throwable t) {
+            throw new Exception(t.getCause().toString());
+        }
         this.parseResult(this.body);
         return this;
     }


### PR DESCRIPTION
- If `isAsync` return an async error
- If null is passed as a param, don't handle this when parsing params. Pass the null value to the sdk and return the sdk error