### PR TITLE
track unmatched scopes and log the test case name that caused them

### DIFF
--- a/harness/features/allFeatures.cloud.test.ts
+++ b/harness/features/allFeatures.cloud.test.ts
@@ -10,9 +10,10 @@ const scope = getServerScope()
 
 describe('allFeatures Tests - Cloud', () => {
     forEachSDK((name) => {
-        const testClient = new CloudTestClient(name)
+        let testClient: CloudTestClient
 
-        beforeAll(async () => {
+        beforeEach(async () => {
+            testClient = new CloudTestClient(name)
             await testClient.createClient({
                 enableCloudBucketing: true,
             })

--- a/harness/features/allFeatures.local.test.ts
+++ b/harness/features/allFeatures.local.test.ts
@@ -13,19 +13,16 @@ describe('allFeatures Tests - Local', () => {
     forEachSDK((name) => {
         describeCapability(name, Capabilities.local)(name, () => {
             describe('uninitialized client', () => {
-                const testClient = new LocalTestClient(name)
+                let testClient: LocalTestClient
 
-                beforeAll(async () => {
+                beforeEach(async () => {
+                    testClient = new LocalTestClient(name)
                     const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
                     scope
                         .get(configRequestUrl)
                         .times(2)
                         .reply(500)
                     await testClient.createClient(true, { configPollingIntervalMS: 60000 })
-                })
-
-                afterAll(async () => {
-                    await testClient.close()
                 })
 
                 it('should return empty object if client is uninitialized',  async () => {
@@ -39,17 +36,14 @@ describe('allFeatures Tests - Local', () => {
             })
 
             describe('initialized client', () => {
-                const testClient = new LocalTestClient(name)
+                let testClient: LocalTestClient
 
-                beforeAll(async () => {
+                beforeEach(async () => {
+                    testClient = new LocalTestClient(name)
                     scope
                         .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
                         .reply(200, config)
                     await testClient.createClient(true, { configPollingIntervalMS: 60000 })
-                })
-
-                afterAll(async () => {
-                    await testClient.close()
                 })
 
                 it('should return all features for user without custom data',  async () => {

--- a/harness/features/allVariables.cloud.test.ts
+++ b/harness/features/allVariables.cloud.test.ts
@@ -14,9 +14,10 @@ describe('allVariables Tests - Cloud', () => {
     forEachSDK((name: string) => {
         let url: string
 
-        const client = new CloudTestClient(name)
+        let client: CloudTestClient
 
-        beforeAll(async () => {
+        beforeEach(async () => {
+            client = new CloudTestClient(name)
             url = getConnectionStringForProxy(name)
             await client.createClient()
         })

--- a/harness/features/allVariables.local.test.ts
+++ b/harness/features/allVariables.local.test.ts
@@ -15,9 +15,10 @@ describe('allVariables Tests - Local', () => {
     forEachSDK((name: string) => {
         let url: string
 
-        const client = new LocalTestClient(name)
+        let client: LocalTestClient
 
-        beforeAll(async () => {
+        beforeEach(async () => {
+            client = new LocalTestClient(name)
             configInterceptor = scope
                 .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
              configInterceptor
@@ -27,10 +28,6 @@ describe('allVariables Tests - Local', () => {
             await client.createClient(true, {
                 configPollingIntervalMS: 60000
             })
-        })
-
-        afterAll(async () => {
-            await client.close()
         })
 
         describeCapability(name, Capabilities.local)(name, () => {
@@ -55,7 +52,6 @@ describe('allVariables Tests - Local', () => {
 
                 expect(variablesMap).toMatchObject({})
                 await waitForRequest(scope, interceptor, 1000, 'Config request never received!')
-                await delayClient.close()
             })
 
             it('should return a variable map for a bucketed user', async () => {

--- a/harness/features/clientCustomData.test.ts
+++ b/harness/features/clientCustomData.test.ts
@@ -47,7 +47,6 @@ describe('Client Custom Data Tests', () => {
                         value: 'string'
                     }
                 }))
-                await client.close()
             })
 
             it('should do nothing when client has not initialized', async () => {
@@ -76,8 +75,6 @@ describe('Client Custom Data Tests', () => {
                         value: 'some-default'
                     }
                 }))
-
-                await client.close()
             })
         })
     })

--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -46,7 +46,6 @@ describe('Initialize Tests - Local', () => {
                 const { message } = await response.json()
 
                 expect(message).toEqual('success')
-                await testClient.close()
             })
 
             it('calls initialize promise/callback when config is successfully retrieved', async () => {
@@ -56,7 +55,6 @@ describe('Initialize Tests - Local', () => {
                     .reply(200, config)
 
                 await testClient.createClient(true, { configPollingIntervalMS: 10000 })
-                await testClient.close()
             })
 
             it('calls initialize promise/callback when config fails to be retrieved', async () => {
@@ -68,7 +66,6 @@ describe('Initialize Tests - Local', () => {
                     .reply(500)
 
                 await testClient.createClient(true, { configPollingIntervalMS: 10000 })
-                await testClient.close()
             })
 
             // TODO DVC-6016 investigate why these were failing on the nodeJS SDK
@@ -103,7 +100,6 @@ describe('Initialize Tests - Local', () => {
                 expect(scope.pendingMocks().length).toEqual(1)
 
                 await wait(3100)
-                await testClient.close()
             }, 5000)
 
             it('uses the same config if the etag matches', async () => {
@@ -129,7 +125,6 @@ describe('Initialize Tests - Local', () => {
                 // make sure the original config is still in use
                 const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
                 expect((await variable.json()).data.value).toEqual(1)
-                await testClient.close()
             })
 
             it('uses the same config if the refetch fails, after retrying once', async () => {
@@ -153,7 +148,6 @@ describe('Initialize Tests - Local', () => {
                 scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
                 const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
                 expect((await variable.json()).data.value).toEqual(1)
-                await testClient.close()
             })
 
             it('uses the same config if the response is invalid JSON', async () => {
@@ -176,7 +170,6 @@ describe('Initialize Tests - Local', () => {
                 scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
                 const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
                 expect((await variable.json()).data.value).toEqual(1)
-                await testClient.close()
             })
 
             it('uses the same config if the response is valid JSON but invalid data', async () => {
@@ -199,7 +192,6 @@ describe('Initialize Tests - Local', () => {
                 scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
                 const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
                 expect((await variable.json()).data.value).toEqual(1)
-                await testClient.close()
             })
         })
     })

--- a/harness/features/track.cloud.test.ts
+++ b/harness/features/track.cloud.test.ts
@@ -17,7 +17,7 @@ describe('Track Tests - Cloud', () => {
 
         let client: CloudTestClient
 
-        beforeAll(async () => {
+        beforeEach(async () => {
             client = new CloudTestClient(name)
             url = getConnectionStringForProxy(name)
             await client.createClient()

--- a/harness/features/track.local.test.ts
+++ b/harness/features/track.local.test.ts
@@ -21,9 +21,10 @@ describe('Track Tests - Local', () => {
 
         describeCapability(name, Capabilities.local)(name, () => {
 
-            const client = new LocalTestClient(name)
+            let client: LocalTestClient
 
-            beforeAll(async () => {
+            beforeEach(async () => {
+                client = new LocalTestClient(name)
                 url = getConnectionStringForProxy(name)
 
                 scope
@@ -35,10 +36,6 @@ describe('Track Tests - Local', () => {
                     logLevel: 'debug',
                     configPollingIntervalMS: 1000 * 60
                 })
-            })
-
-            afterAll(async () => {
-                await client.close()
             })
 
             describe('Expect no events sent', () => {

--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -15,9 +15,10 @@ describe('Variable Tests - Cloud', () => {
     // for each SDK, and creates a test client from the name.
     // All supported SDKs can be found under harness/types/sdks.ts
     forEachSDK((name) => {
-        const testClient = new CloudTestClient(name)
+        let testClient: CloudTestClient
 
-        beforeAll(async () => {
+        beforeEach(async () => {
+            testClient = new CloudTestClient(name)
             // Creating a client will pass to the proxy server by default:
             // - sdk key based on the client id created when creating the client
             // - urls for the bucketing/config/events endpoints to redirect traffic

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -60,11 +60,12 @@ describe('Variable Tests - Local', () => {
         // Capabilities are located under harness/types/capabilities and follow the same
         // name mapping from the sdks.ts file under harness/types/sdks.ts
         describeCapability(name, Capabilities.local)(name, () => {
-            const testClient = new LocalTestClient(name)
+            let testClient: LocalTestClient
             let eventsUrl: string
 
             describe('initialized client', () => {
-                beforeAll(async () => {
+                beforeEach(async () => {
+                    testClient = new LocalTestClient(name)
                     // This allows us to mock out the our specific client (using the clientId),
                     // allowing us to have multiple clients serving different clients without
                     // conflicting. This one is used to mock the config that the local client is going to use
@@ -89,10 +90,6 @@ describe('Variable Tests - Local', () => {
                     })
 
                     eventsUrl = `/client/${testClient.clientId}/v1/events/batch`
-                })
-
-                afterAll(async () => {
-                    await testClient.close()
                 })
 
                 // Instead of writing tests for each different type we support (String, Boolean, Number, JSON),
@@ -254,9 +251,10 @@ describe('Variable Tests - Local', () => {
             })
 
             describe('uninitialized client', () => {
-                const testClient = new LocalTestClient(name)
+                let testClient: LocalTestClient
 
-                beforeAll(async () => {
+                beforeEach(async () => {
+                    testClient = new LocalTestClient(name)
                     const configRequestUrl = `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`
                     const interceptor = scope
                         .get(configRequestUrl)
@@ -274,10 +272,6 @@ describe('Variable Tests - Local', () => {
                         3000,
                         'Config request timed out'
                     )
-                })
-
-                afterAll(async () => {
-                    await testClient.close()
                 })
 
                 forEachVariableType((type) => {

--- a/harness/mockServer/index.ts
+++ b/harness/mockServer/index.ts
@@ -10,11 +10,18 @@ import bodyParser from 'koa-bodyparser'
 
 let unmatchedRequests = []
 
-export const assertNoUnmatchedRequests = async () => {
+export const assertNoUnmatchedRequests = async (currentClientId, testNameMap) => {
     if (unmatchedRequests.length > 0) {
         const currentUnmatchedRequests = unmatchedRequests
         unmatchedRequests = []
-        throw new Error('Unmatched requests: ' + currentUnmatchedRequests)
+        const url = currentUnmatchedRequests[0].config.url
+        const clientId = url.split('/')[4]
+        if (url.includes(currentClientId)) {
+            throw new Error('Unmatched requests: ' + currentUnmatchedRequests)
+        } else {
+            const testName = testNameMap[clientId]
+            throw new Error(`Unmatched requests from test case ${testName} ` + currentUnmatchedRequests)
+        }
     }
 }
 


### PR DESCRIPTION
- keep track of the current client instance being used for tests
- keep a record of which test case name created that client
- throw error if a test client is created outside the scope of an individual test case
- change all test files to create a new client for each test
- add the test case name that caused the unmatched nock scope error to the message that is thrown (if the test case is different than the current one)
- automatically call the client `close` method at the end of each test case
- remove all manual calls to client.close