### PR TITLE
add test for receiving new config during test and seeing new variable

### DIFF
--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -99,7 +99,7 @@ describe('Variable Tests - Local', () => {
                 forEachVariableType((type) => {
                     const { key, defaultValue, variationOn, variableType } = expectedVariablesByType[type]
 
-                    it('should return variable if mock server returns object matching default type', async () => {
+                    it('should return variable if SDK returns object matching default type',  async () => {
                         let eventBody = {}
                         // The interceptor instance is used to wait on events that are triggered when calling
                         // methods so that we can verify events being sent out and mock out responses from the

--- a/harness/mockData/config.ts
+++ b/harness/mockData/config.ts
@@ -182,6 +182,37 @@ export const config: ConfigBody = {
     }
 }
 
+export const config2 = {
+    ...config,
+    features: [
+        {
+            ...config.features[0],
+            variations: [
+                {
+                    ...config.features[0].variations[0],
+                    "variables": [{
+                        "_var": "638681f059f1b81cc9e6c7fa",
+                        "value": false
+                    }, {
+                        "_var": "638681f059f1b81cc9e6c7fb",
+                        "value": "string2"
+                    }, {
+                        "_var": "638681f059f1b81cc9e6c7fc",
+                        "value": 2
+                    }, {
+                        "_var": "638681f059f1b81cc9e6c7fd",
+                        "value": {
+                            "facts": "indeed"
+                        }
+                    }],
+                },
+                ...config.features[0].variations.slice(1)
+            ]
+        },
+        ...config.features.slice(1)
+    ]
+}
+
 export const expectedFeaturesVariationOn = {
     'test-harness': {
         _id: '638680d6fcb67b96878d90e6',

--- a/proxies/go/handler_command.go
+++ b/proxies/go/handler_command.go
@@ -62,8 +62,6 @@ func locationCommandHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func commandHandler(locationIsClient bool, w http.ResponseWriter, r *http.Request) {
-	commandMutex.Lock()
-	defer commandMutex.Unlock()
 	var body CommandBody
 	jsonErr := json.NewDecoder(r.Body).Decode(&body)
 
@@ -227,6 +225,9 @@ func callMethodOnEntity(
 
 	locationId := strconv.Itoa(len(datastore.commandResults[command]))
 	locationHeader := "command/" + command + "/" + locationId
+
+	commandMutex.Lock()
+	defer commandMutex.Unlock()
 
 	datastore.commandResults[command][locationId] = result[0]
 

--- a/proxies/go/handler_command.go
+++ b/proxies/go/handler_command.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	devcycle "github.com/devcyclehq/go-server-sdk/v2"
 	"github.com/gorilla/mux"
@@ -39,6 +40,8 @@ type ErrorResponse struct {
 	Stack      error  `json:"stack"`
 }
 
+var commandMutex = sync.Mutex{}
+
 func handleError(r any, err *error) {
 	switch x := r.(type) {
 	case string:
@@ -59,6 +62,8 @@ func locationCommandHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func commandHandler(locationIsClient bool, w http.ResponseWriter, r *http.Request) {
+	commandMutex.Lock()
+	defer commandMutex.Unlock()
 	var body CommandBody
 	jsonErr := json.NewDecoder(r.Body).Decode(&body)
 


### PR DESCRIPTION
- add new multi threading test that simulates receiving a new config and tests that the variable call correctly returns the new value
- also fixes multithreaded access to commandResults in Go proxy by putting a mutex around the operation that stores the results 