### PR TITLE
DEV-6791: Add configuration for Go native SDK

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,13 +48,24 @@ services:
     container_name: go
     ports:
       - "3000"
+  gonative:
+    build:
+      context: ./proxies/go
+      args:
+        - GO_SDK_VERSION=${GO_SDK_VERSION}
+        - SDK_GITHUB_SHA=${SDK_GITHUB_SHA}
+        - SDKS_TO_TEST=${SDKS_TO_TEST}
+        - GO_BUILD_TAGS=native_bucketing
+    container_name: gonative
+    ports:
+      - "3000"
   ruby:
-   build:
-     context: ./proxies/ruby
-     args:
-       - RUBY_SDK_VERSION=${RUBY_SDK_VERSION}
-       - SDK_GITHUB_SHA=${SDK_GITHUB_SHA}
-       - SDKS_TO_TEST=${SDKS_TO_TEST}
-   container_name: ruby
-   ports:
-     - "3000"
+    build:
+      context: ./proxies/ruby
+      args:
+        - RUBY_SDK_VERSION=${RUBY_SDK_VERSION}
+        - SDK_GITHUB_SHA=${SDK_GITHUB_SHA}
+        - SDKS_TO_TEST=${SDKS_TO_TEST}
+    container_name: ruby
+    ports:
+      - "3000"

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -471,6 +471,10 @@ export const expectErrorMessageToBe = (message: string, expected: string) => {
 }
 
 export const getPlatformBySdkName = (name: string, isLocal: boolean) => {
+    // GoNative is using the same SDK as Go but with different build args
+    if (name === 'GoNative') {
+        return 'Go'
+    }
     return name === 'DotNet' ? // TODO use Sdks.dotnet instead of 'DotNet' when enable dotnet
         `C# ${isLocal ? 'Local' : 'Cloud'}`
         : name

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -13,5 +13,6 @@ export const SDKCapabilities = {
     DotNet: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
     Java: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
     Go: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData, Capabilities.multithreading],
+    GoNative: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData, Capabilities.multithreading],
     Ruby: [Capabilities.local, Capabilities.clientCustomData]
 }

--- a/harness/types/sdks.ts
+++ b/harness/types/sdks.ts
@@ -2,6 +2,7 @@ export const Sdks = {
     nodejs: 'NodeJS',
     dotnet: 'DotNet',
     go: 'Go',
+    gonative: 'GoNative',
     ruby: 'Ruby',
     // TODO uncomment once Java is ready
     // java: 'Java'

--- a/proxies/go/Dockerfile
+++ b/proxies/go/Dockerfile
@@ -11,6 +11,9 @@ ENV SDK_GITHUB_SHA $SDK_GITHUB_SHA
 ARG SDKS_TO_TEST
 ENV SDKS_TO_TEST $SDKS_TO_TEST
 
+ARG GO_BUILD_TAGS
+ENV GO_BUILD_TAGS ${GO_BUILD_TAGS:+-tags $GO_BUILD_TAGS}
+
 WORKDIR /app
 COPY go.mod ./
 COPY go.sum ./
@@ -20,7 +23,7 @@ RUN ./install.sh
 
 RUN go mod download
 COPY *.go ./
-RUN go build -o proxy .
+RUN go build -o proxy ${GO_BUILD_TAGS} .
 
 EXPOSE 3000
 ENTRYPOINT ["./proxy"]


### PR DESCRIPTION
This is actually an alternate build of the existing go-server-sdk, so we
have to trick the tests a little to allow this.

Tests pass locally, and there's nothing really different between the two right now, so I expect this to work on main.