### PR TITLE
Fix path for test output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,5 +39,5 @@ runs:
       if: success() || failure()    # run this step even if previous step failed
       with:
         name: JEST Tests            # Name of the check run which will be created
-        path: reports/jest-*.xml    # Path to test results
+        path: jest-*.xml    # Path to test results
         reporter: jest-junit        # Format of test results


### PR DESCRIPTION
The action had slightly different config from the test-harness internal tests.