### PR TITLE
Limit capabilities for Go native SDK and exclude more tests

### DIFF
--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -3,7 +3,8 @@ import {
     wait,
     LocalTestClient,
     describeCapability,
-    expectErrorMessageToBe
+    expectErrorMessageToBe,
+    hasCapability
 } from '../helpers'
 import { Capabilities } from '../types'
 import { config, shouldBucketUser } from '../mockData'
@@ -121,7 +122,11 @@ describe('Initialize Tests - Local', () => {
 
                 await wait(1100)
                 expect(scope.pendingMocks().length).toEqual(0)
-                scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+
+                if (hasCapability(name, Capabilities.events)) {
+                    scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+                }
+
                 // make sure the original config is still in use
                 const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
                 expect((await variable.json()).data.value).toEqual(1)
@@ -145,7 +150,9 @@ describe('Initialize Tests - Local', () => {
                 await wait(1500)
                 expect(scope.pendingMocks().length).toEqual(0)
                 // make sure the original config is still in use
-                scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+                if (hasCapability(name, Capabilities.events)) {
+                    scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+                }
                 const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
                 expect((await variable.json()).data.value).toEqual(1)
             })
@@ -167,7 +174,9 @@ describe('Initialize Tests - Local', () => {
                 await wait(1200)
                 expect(scope.pendingMocks().length).toEqual(0)
                 // make sure the original config is still in use
-                scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+                if (hasCapability(name, Capabilities.events)) {
+                    scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+                }
                 const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
                 expect((await variable.json()).data.value).toEqual(1)
             })
@@ -189,7 +198,9 @@ describe('Initialize Tests - Local', () => {
                 await wait(1200)
                 expect(scope.pendingMocks().length).toEqual(0)
                 // make sure the original config is still in use
-                scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+                if (hasCapability(name, Capabilities.events)) {
+                    scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
+                }
                 const variable = await testClient.callVariable(shouldBucketUser, 'number-var', 0)
                 expect((await variable.json()).data.value).toEqual(1)
             })

--- a/harness/features/track.local.test.ts
+++ b/harness/features/track.local.test.ts
@@ -20,7 +20,7 @@ describe('Track Tests - Local', () => {
         let url: string
         const eventFlushIntervalMS = 1000
 
-        describeCapability(name, Capabilities.local)(name, () => {
+        describeCapability(name, Capabilities.local, Capabilities.events)(name, () => {
 
             let client: LocalTestClient
 

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -60,7 +60,7 @@ describe('Variable Tests - Local', () => {
         // This describeCapability only runs if the SDK has the "local" capability.
         // Capabilities are located under harness/types/capabilities and follow the same
         // name mapping from the sdks.ts file under harness/types/sdks.ts
-        describeCapability(name, Capabilities.local)(name, () => {
+        describeCapability(name, Capabilities.local, Capabilities.events)(name, () => {
             let testClient: LocalTestClient
             let eventsUrl: string
 

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -75,8 +75,12 @@ export const forEachSDK = (tests) => {
 
 export const describeIf = (condition: boolean) => condition ? describe : describe.skip
 
-export const describeCapability = (sdkName: string, capability: string) => {
-    return describeIf(SDKCapabilities[sdkName].includes(capability))
+export const describeCapability = (sdkName: string, ...capabilities: string[]) => {
+    return describeIf(capabilities.every((capability) => SDKCapabilities[sdkName].includes(capability)))
+}
+
+export const hasCapability = (sdkName: string, capability: string) => {
+    return SDKCapabilities[sdkName].includes(capability)
 }
 
 export const forEachVariableType = (tests) => {

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -1,5 +1,6 @@
 export const Capabilities = {
     edgeDB: 'EdgeDB',
+    events: 'Events',
     local: 'LocalBucketing',
     cloud: 'CloudBucketing',
     sse: 'SSE',
@@ -8,11 +9,11 @@ export const Capabilities = {
 }
 
 export const SDKCapabilities = {
-    NodeJS: [Capabilities.edgeDB, Capabilities.local, Capabilities.cloud],
-    Python: [Capabilities.cloud, Capabilities.edgeDB],
-    DotNet: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
-    Java: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
-    Go: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData, Capabilities.multithreading],
-    GoNative: [Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData, Capabilities.multithreading],
-    Ruby: [Capabilities.local, Capabilities.clientCustomData]
+    NodeJS: [Capabilities.events, Capabilities.edgeDB, Capabilities.local, Capabilities.cloud],
+    Python: [Capabilities.events, Capabilities.cloud, Capabilities.edgeDB],
+    DotNet: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
+    Java: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
+    Go: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData, Capabilities.multithreading],
+    GoNative: [Capabilities.local],
+    Ruby: [Capabilities.events, Capabilities.local, Capabilities.clientCustomData]
 }


### PR DESCRIPTION
This should get the Go native SDK tests passing in a very minimal way.  We can add back capabilities as we get more things working.
