### PR TITLE
Add clientCustomData to dotnet SDK tests

### DIFF
--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -11,7 +11,7 @@ export const Capabilities = {
 export const SDKCapabilities = {
     NodeJS: [Capabilities.events, Capabilities.edgeDB, Capabilities.local, Capabilities.cloud],
     Python: [Capabilities.events, Capabilities.cloud, Capabilities.edgeDB],
-    DotNet: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
+    DotNet: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData],
     Java: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
     Go: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData, Capabilities.multithreading],
     GoNative: [Capabilities.local, Capabilities.clientCustomData, Capabilities.events],

--- a/proxies/dotnet/Controllers/Location.cs
+++ b/proxies/dotnet/Controllers/Location.cs
@@ -91,6 +91,8 @@ public class LocationController : ControllerBase
             };
 
         } catch (Exception e) {
+            Console.WriteLine("[COMMAND ERROR] " + body.Command + ": " + e);
+
             Response.StatusCode = 200;
 
             if (body.IsAsync) {
@@ -194,6 +196,12 @@ public class LocationController : ControllerBase
         if (command == "variable") {
             Type defaultValueClass = parsedParams[parsedParams.Count - 1].GetType();
             commandMethod = commandMethod?.MakeGenericMethod(defaultValueClass); // have to set the generic type for defaultValue before invoke
+        }
+        else if(parsedCommand == "SetClientCustomData") {
+            // need to convert from a JObject to a Dictionary<string, object> to match the method signature
+            var customDataJson = parsedParams[0] as JObject;
+            var customDataDict = customDataJson.ToObject<Dictionary<string, object>>();
+            parsedParams[0] = customDataDict;
         }
 
         object result = null;


### PR DESCRIPTION
.Net SDK now has setClientCustomData support for WASM and needs to be tested by the harness