### PR TITLE
enable client custom data tests for gonative

### DIFF
--- a/harness/features/clientCustomData.test.ts
+++ b/harness/features/clientCustomData.test.ts
@@ -3,6 +3,7 @@ import {
     forEachSDK,
     LocalTestClient,
     describeCapability,
+    hasCapability,
     waitForRequest
 } from '../helpers'
 import { Capabilities } from '../types'
@@ -26,15 +27,17 @@ describe('Client Custom Data Tests', () => {
                     .get(`/client/${client.clientId}/config/v1/server/${client.sdkKey}.json`)
                     .reply(200, config)
 
-                scope
-                    .post(`/client/${client.clientId}/v1/events/batch`)
-                    .reply(201)
+                if (hasCapability(name, Capabilities.events)) {
+                    scope
+                        .post(`/client/${client.clientId}/v1/events/batch`)
+                        .reply(201)
+                }
 
 
                 const customData = { 'should-bucket': true }
                 await client.createClient(true)
                 await client.callSetClientCustomData(customData)
-                const user = { user_id: 'test-user'}
+                const user = { user_id: 'test-user' }
                 const response = await client.callVariable(user, 'string-var', 'some-default')
                 const variable = await response.json()
                 expect(variable).toEqual(expect.objectContaining({
@@ -63,7 +66,9 @@ describe('Client Custom Data Tests', () => {
                 await client.callSetClientCustomData(customData)
                 await waitForRequest(scope, configCall, 1000, 'Config request timed out')
 
-                scope.post(`/client/${client.clientId}/v1/events/batch`).reply(201)
+                if (hasCapability(name, Capabilities.events)) {
+                    scope.post(`/client/${client.clientId}/v1/events/batch`).reply(201)
+                }
 
                 const response = await client.callVariable({ user_id: 'user-id' }, 'string-var', 'some-default')
                 const variable = await response.json()

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -262,7 +262,13 @@ const checkFailed = async (response: Response, shouldFail: boolean) => {
             throw new Error(`Request failed with status ${response.status}, ${await response.text()}`)
         }
         const result = await response.clone().json()
+        if (result.exception) {
+            console.log(`Exception: ${result.exception.constructor} ${result.exception}`)
+        }
         expect(result.exception).toBeUndefined()
+        if (result.asyncError) {
+            console.log(`AsyncError: ${result.exception.constructor} ${result.asyncError}`)
+        }
         expect(result.asyncError).toBeUndefined()
     } else {
         const result = await response.clone().json()

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -227,7 +227,7 @@ export const waitForRequest = async (
     timeout: number,
     timeoutMessage: string
 ) => {
-    if (scope.isDone()){
+    if (scope.isDone()) {
         return
     }
 
@@ -293,7 +293,7 @@ class BaseTestClient {
         return (new URL(this.clientLocation ?? '', getConnectionStringForProxy(this.sdkName))).href
     }
 
-    async close() {}
+    async close() { }
 }
 
 export class LocalTestClient extends BaseTestClient {

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -14,6 +14,6 @@ export const SDKCapabilities = {
     DotNet: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
     Java: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB],
     Go: [Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData, Capabilities.multithreading],
-    GoNative: [Capabilities.local],
+    GoNative: [Capabilities.local, Capabilities.clientCustomData],
     Ruby: [Capabilities.events, Capabilities.local, Capabilities.clientCustomData]
 }


### PR DESCRIPTION
This turns the client custom data tests back on for the gonative SDK.
I made the events endpoint stubs only set up when events are supported - otherwise they fail the test when they're not hit.

This PR will fail until DevCycleHQ/go-server-sdk#159 is merged.