### PR TITLE
Support local flow natively and speed up single SDK runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently it includes tests for serverside SDKs, for both cloud and local bucket
 The tests are written in Jest and run against a series of "proxy servers" written in the native language of each SDK.
 
 ## Running the Tests
-### Preqrequisites
+### Prerequisites
 You must have Docker installed and running on your machine. You must also have a working copy of Node 18+ and Yarn.
 
 ### Steps
@@ -35,22 +35,22 @@ a particular test file, or using `it.only` to run only a single test within a fi
 It is also typically necessary to run the SDK proxy server locally in order to log / debug what is going on.
 See the section below on running the harness against a local SDK.
 
+If debugging tests against a known version, you can speed up iteration by running with the watch flag:
+```
+yarn test --watch
+```
+That will keep the docker containers running the proxies alive, and pop up a menu in the terminal for re-running tests, failures, etc.
+
 ## Running the harness against a local SDK
-For an easy way to just get the configurations set up the "recommended" way, simply run:
-`yarn use-local`
 
-this will apply the changes from a special branch in the repo containing the local configurations. To do this you must
-have a "clean" working directory with no uncommitted changes. Make sure not to commit the changed configuration files
-when running in local mode!
-
-You can then run the proxy server for the SDK you want to work on using:
+You can run the proxy server for the SDK you want to work on using:
 `yarn start:{sdk}` eg. `yarn start:nodejs`
 
 When running proxy tests, use the following environment variables to specify local mode:
 
-`LOCAL_MODE=1`
-
-`SDKS_TO_TEST=nodejs`
+```
+LOCAL_MODE=1 SDKS_TO_TEST=nodejs yarn test
+```
 
 You may still need to run the package manager for the particular proxy (e.g. `yarn`, `go mod tidy` etc.)
 , see [this document](docs/LOCAL.md) for details on how to run the proxies.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.7"
 
 services:
   nodejs:
+    profiles:
+      - nodejs
     build:
       context: ./proxies/nodejs
       args:
@@ -11,15 +13,19 @@ services:
     container_name: nodejs
     ports:
       - "3000"
-#  python:
-#    build:
-#      context: ./proxies/python
-#      args:
-#        - PYTHON_SDK_VERSION=${PYTHON_SDK_VERSION}
-#    container_name: python
-#    ports:
-#      - "3000"
+  python:
+    profiles:
+      - python
+    build:
+      context: ./proxies/python
+      args:
+        - PYTHON_SDK_VERSION=${PYTHON_SDK_VERSION}
+    container_name: python
+    ports:
+      - "3000"
   dotnet:
+    profiles:
+      - dotnet
     build:
       context: ./proxies/dotnet
       args:
@@ -30,15 +36,19 @@ services:
     container_name: dotnet
     ports:
       - "3000"
-# java:
-#   build:
-#     context: ./proxies/java
-#     args:
-#       - JAVA_SDK_VERSION=${JAVA_SDK_VERSION}
-#   container_name: java
-#   ports:
-#     - "3000"
+  java:
+    profiles:
+      - java
+    build:
+      context: ./proxies/java
+      args:
+        - JAVA_SDK_VERSION=${JAVA_SDK_VERSION}
+    container_name: java
+    ports:
+      - "3000"
   go:
+    profiles:
+      - go
     build:
       context: ./proxies/go
       args:
@@ -49,6 +59,8 @@ services:
     ports:
       - "3000"
   gonative:
+    profiles:
+      - gonative
     build:
       context: ./proxies/go
       args:
@@ -60,6 +72,8 @@ services:
     ports:
       - "3000"
   ruby:
+    profiles:
+      - ruby
     build:
       context: ./proxies/ruby
       args:

--- a/docs/GUIDE.MD
+++ b/docs/GUIDE.MD
@@ -6,7 +6,7 @@ _Refer to the Variable Cloud tests and Variable Local tests on how to write test
 
 The test harness is built using `jest-testcontainers` which can run docker containers that can be used in our tests. The test harness uses it to spin up
 proxy servers, written in the language they are meant to test.The `docker-compose.yml` file lists the images that are to be spun up when the tests start up.
-There is also `jest-environment.ts` where some globals are set up and where the mock API server is setup and torn down.
+There is also `jest-environment.ts` where some globals are set up and where the mock API server is setup and torn down. The global setup used by `jest-testcontainers` is wrapped in `jest-global.ts` to set the profiles used by docker-compose. This limits which containers are actually built and run based on their `profiles` setting.
 
 The tests send commands to the proxy server through http requests, the spec of which you can find at `docs/spec.yaml`. The proxy server then calls the SDK based on the request from the test harness and will respond back with the results to the test harness. The SDK is also configured by the test harness to point all API calls to the mock server using `nock`; the proxy server initializes the SDK with options that change the base URL to the urls passed by the proxy server. This allows us to mock API calls from the SDK.
 

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -41,20 +41,28 @@ export const getConnectionStringForProxy = (proxy: string) => {
 let currentClient: BaseTestClient
 const clientTestNameMap: Record<string, string> = {}
 
-export const forEachSDK = (tests) => {
-    // get the list of SDK's and their capabilities
-    let SDKs
+// Extract the list of SDKs to test from the environment variable SDKS_TO_TEST
+// It can be formatted as a JSON array or a comma-separated list.
+// The SDKs are returned as their human-readable names from the Sdks enum, not the enum keys.
+export const getSDKs = () => {
     try {
-        SDKs = JSON.parse(process.env.SDKS_TO_TEST ?? '').map((sdk) => Sdks[sdk])
+        return JSON.parse(process.env.SDKS_TO_TEST ?? '').map((sdk) => Sdks[sdk])
     } catch (e) {
-        if (process.env.SDKS_TO_TEST && Sdks[process.env.SDKS_TO_TEST]) {
-            SDKs = [Sdks[process.env.SDKS_TO_TEST]]
+        if (process.env.SDKS_TO_TEST) {
+            return process.env.SDKS_TO_TEST.split(',')
+                .map((sdk) => Sdks[sdk])
+                .filter((sdkName) => sdkName !== undefined)
         } else {
-            console.log('No specified SDKs to test, running all tests')
-            SDKs = Object.values(Sdks)
+            console.warn('No specified SDKs to test, running all tests')
+            return Object.values(Sdks)
         }
     }
+}
+
+export const forEachSDK = (tests) => {
     const scope = getServerScope()
+
+    const SDKs = getSDKs()
 
     describe.each(SDKs)('%s SDK tests', (name) => {
         afterEach(async () => {

--- a/jest-global.ts
+++ b/jest-global.ts
@@ -1,0 +1,24 @@
+import {
+    getSDKs
+} from './harness/helpers'
+import testContainersSetup from '@trendyol/jest-testcontainers/dist/setup'
+
+async function setup(opts) {
+    const sdks = getSDKs()
+
+    console.log(`Setting up test containers for SDKs: ${sdks.join(', ')}`)
+
+    // COMPOSE_PROFILES controls which docker-compose services are run via their profiles setting in docker-compose.yml
+    process.env.COMPOSE_PROFILES = sdks.map((sdkName: string) => sdkName.toLowerCase()).join(',')
+    
+    if (process.env.LOCAL_MODE === '1') {
+        // Effectively disable all docker containers by setting a profile that none of them use
+        process.env.COMPOSE_PROFILES = 'local'
+    }
+
+    console.log(`Set COMPOSE_PROFILES to ${process.env.COMPOSE_PROFILES}`)
+
+    return await testContainersSetup(opts)
+}
+
+module.exports = setup

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,8 @@ module.exports = {
     transform: {
         '^.+\\.tsx?$': ['ts-jest', {}]
     },
+    globalSetup: './jest-global.ts',
     testEnvironment: './jest-environment.ts',
-    setupFilesAfterEnv: ["./jest-setup.js"],
+    setupFilesAfterEnv: ['./jest-setup.js'],
     testTimeout: 60000,
-};
+}


### PR DESCRIPTION
This uses docker-compose's profiles support to limit which services are actually run by Jest, and adds support for a native local flow by disabling them all.

Most single SDK runs should be significantly faster since only the one image needs to be built and started.

I've uncommented the docker-compose services for the not-yet-supported SDKs, because they're now effectively disabled via profiles until we enable them in the `Sdks` enum.