### PR TITLE
DVC 7423: Update to test default native bucketing in Go SDK

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,17 +77,17 @@ services:
     container_name: go
     ports:
       - "3000"
-  gonative:
+  gowasm:
     profiles:
-      - gonative
+      - gowasm
     build:
       context: ./proxies/go
       args:
         - GO_SDK_VERSION=${GO_SDK_VERSION}
         - SDK_GITHUB_SHA=${SDK_GITHUB_SHA}
         - SDKS_TO_TEST=${SDKS_TO_TEST}
-        - GO_BUILD_TAGS=native_bucketing
-    container_name: gonative
+        - GO_BUILD_TAGS=devcycle_wasm_bucketing
+    container_name: gowasm
     ports:
       - "3000"
   ruby:

--- a/harness/features/multithreading.local.test.ts
+++ b/harness/features/multithreading.local.test.ts
@@ -95,7 +95,7 @@ describe('Multithreading Tests', () => {
             it('should aggregate events across threads', async () => {
                 const eventBodies = []
 
-                const interceptor = scope.post(eventsUrl).times(2)
+                const interceptor = scope.post(eventsUrl)
                 interceptor.reply((uri, body) => {
                     eventBodies.push( body)
                     return [201]
@@ -135,21 +135,17 @@ describe('Multithreading Tests', () => {
                 // waits for the request to the events API
                 await waitForRequest(scope, interceptor, 600, 'Event callback timed out')
 
-                // Expect that the SDK sends an "aggVariableEvaluated" event per thread
-                expectEventBody(eventBodies[0], key, 'aggVariableEvaluated', expect.any(Number))
-                expectEventBody(eventBodies[1], key, 'aggVariableEvaluated', expect.any(Number))
-                // expect that in total we tracked four evaluations
-                expect(eventBodies[0].batch[0].events[0].value + eventBodies[1].batch[0].events[0].value).toEqual(4)
+                // Expect that the SDK sends a single "aggVariableEvaluated" event
+                expect(eventBodies.length).toEqual(1)
+                expectEventBody(eventBodies[0], key, 'aggVariableEvaluated', 4)
             })
 
             it('should retry events across threads', async () => {
                 const eventBodies = []
 
-                const interceptor1 = scope.post(eventsUrl).times(2)
+                scope.post(eventsUrl).reply(500)
 
-                interceptor1.reply(500)
-
-                const interceptor2 = scope.post(eventsUrl).times(2)
+                const interceptor2 = scope.post(eventsUrl)
                 interceptor2.reply((uri, body) => {
                     eventBodies.push( body)
                     return [201]
@@ -187,21 +183,17 @@ describe('Multithreading Tests', () => {
                 ])
 
                 // waits for the request to the events API
-                await waitForRequest(scope, interceptor1, 600, 'Initial event requests not received')
-                await waitForRequest(scope, interceptor2, 600, 'Retried event requests not received')
+                await waitForRequest(scope, interceptor2, 1200, 'Retried event requests not received')
 
-                // Expect that the SDK sends an "aggVariableEvaluated" event per thread
-                expectEventBody(eventBodies[0], key, 'aggVariableEvaluated', expect.any(Number))
-                expectEventBody(eventBodies[1], key, 'aggVariableEvaluated', expect.any(Number))
-                // expect that in total we tracked four evaluations
-                expect(eventBodies[0].batch[0].events[0].value + eventBodies[1].batch[0].events[0].value).toEqual(4)
+                // Expect that the SDK sends a single "aggVariableEvaluated" event
+                expect(eventBodies.length).toEqual(1)
+                expectEventBody(eventBodies[0], key, 'aggVariableEvaluated', 4)
             })
 
             describeCapability(sdkName, Capabilities.clientCustomData)(sdkName, () => {
                 it('should set client custom data and use it for segmentation', async () => {
                     const interceptor = scope
                         .post(eventsUrl)
-                        .times(2)
 
                     interceptor
                         .reply(201)

--- a/harness/helpers.ts
+++ b/harness/helpers.ts
@@ -596,8 +596,8 @@ export const expectErrorMessageToBe = (message: string, expected: string) => {
 }
 
 export const getPlatformBySdkName = (name: string, isLocal: boolean) => {
-    // GoNative is using the same SDK as Go but with different build args
-    if (name === 'GoNative') {
+    // GoWASM is using the same SDK as Go but with different build args
+    if (name === 'GoWASM') {
         return 'Go'
     }
     if (name === 'OF-NodeJS') {

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -31,8 +31,7 @@ export const SDKCapabilities = {
         Capabilities.multithreading, Capabilities.variableValue
     ],
     GoWASM: [
-        Capabilities.events, Capabilities.local, Capabilities.clientCustomData, Capabilities.multithreading,
-        Capabilities.variableValue
+        Capabilities.events, Capabilities.local, Capabilities.clientCustomData, Capabilities.variableValue
     ],
     Ruby: [
         Capabilities.events, Capabilities.local, Capabilities.clientCustomData, Capabilities.variableValue

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -30,8 +30,9 @@ export const SDKCapabilities = {
         Capabilities.events, Capabilities.cloud, Capabilities.local, Capabilities.edgeDB, Capabilities.clientCustomData,
         Capabilities.multithreading, Capabilities.variableValue
     ],
-    GoNative: [
-        Capabilities.local, Capabilities.clientCustomData, Capabilities.events, Capabilities.variableValue
+    GoWASM: [
+        Capabilities.events, Capabilities.local, Capabilities.clientCustomData, Capabilities.multithreading,
+        Capabilities.variableValue
     ],
     Ruby: [
         Capabilities.events, Capabilities.local, Capabilities.clientCustomData, Capabilities.variableValue

--- a/harness/types/sdks.ts
+++ b/harness/types/sdks.ts
@@ -3,7 +3,7 @@ export const Sdks = {
     'of-nodejs': 'OF-NodeJS',
     dotnet: 'DotNet',
     go: 'Go',
-    gonative: 'GoNative',
+    gowasm: 'GoWASM',
     ruby: 'Ruby',
     // TODO uncomment once Java is ready
     // java: 'Java'

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -45,9 +45,9 @@ const projects = [
     },
     {
         ...commonConfig,
-        displayName: 'GoNative',
+        displayName: 'GoWASM',
         globals: {
-            JEST_PROJECT_SDK_TO_TEST: 'GoNative',
+            JEST_PROJECT_SDK_TO_TEST: 'GoWASM',
             LOCAL_HOST_BINDING: '0.0.0.0'
         }
     },


### PR DESCRIPTION
This changes the default Go tests to target the native code that will be turned on by default in DevCycleHQ/go-server-sdk#194.

I modified the multithreading tests as they had assumptions built in around the division of event into multiple batches by the multiple WASM workers. That's no longer true with the native Go SDK.

I've tested this locally against [a354811](https://github.com/DevCycleHQ/go-server-sdk/pull/194/commits/a3548118f75b23f224292928f60fa3b3f7693fd3) and confirmed that both Go and GoWASM pass.