### PR TITLE
[fix] Python Proxy not pulling SHA properly

### DIFF
--- a/proxies/python/install.sh
+++ b/proxies/python/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [[ -n "$SDK_GITHUB_SHA" ]]; then
+if [ -n "$SDK_GITHUB_SHA" ]; then
     echo "Checking out python SDK at $SDK_GITHUB_SHA"
     cd ..
     git clone https://github.com/DevCycleHQ/python-server-sdk.git


### PR DESCRIPTION
fixed issue where GITHUB SHA env var wasn't triggering a proper initialization of the proxy