### PR TITLE
chore: Update DotNet proxy to match DVC -> DevCycle refactoring

### DIFF
--- a/proxies/dotnet/Controllers/Client.cs
+++ b/proxies/dotnet/Controllers/Client.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace dotnet.Controllers;
 
-public class ClientOptions : DVCLocalOptions
+public class ClientOptions : DevCycleLocalOptions
 {
     [JsonProperty("eventFlushIntervalMS")]
     public int EventFlushIntervalMsOverride { get; set; }
@@ -78,17 +78,17 @@ public class ClientController : ControllerBase
         {
             if (ClientBody.EnableCloudBucketing ?? false)
             {
-                DVCCloudOptions cloudOptions = new DVCCloudOptions();
+                DevCycleCloudOptions cloudOptions = new DevCycleCloudOptions();
 
                 if (ClientBody.Options != null)
-                    cloudOptions = new DVCCloudOptions(enableEdgeDB: ClientBody.Options.EnableEdgeDB ?? false);
+                    cloudOptions = new DevCycleCloudOptions(enableEdgeDB: ClientBody.Options.EnableEdgeDB ?? false);
 
-                var RestOptions = new DevCycle.SDK.Server.Common.API.DVCRestClientOptions();
+                var RestOptions = new DevCycle.SDK.Server.Common.API.DevCycleRestClientOptions();
 
                 if (ClientBody.Options?.BucketingAPIURLOverride != null)
                     RestOptions.BaseUrl = new Uri(ClientBody.Options.BucketingAPIURLOverride);
 
-                DataStore.CloudClients[ClientBody.ClientId] = new DVCCloudClientBuilder()
+                DataStore.CloudClients[ClientBody.ClientId] = new DevCycleCloudClientBuilder()
                     .SetEnvironmentKey(ClientBody.SdkKey)
                     .SetOptions(cloudOptions)
                     .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
@@ -114,9 +114,9 @@ public class ClientController : ControllerBase
 
                 if (ClientBody.WaitForInitialization == true) {
                     Task task = new Task(() => {});
-                    DevCycle.SDK.Server.Common.Model.DVCEventArgs? eventArgs = null;
+                    DevCycle.SDK.Server.Common.Model.DevCycleEventArgs? eventArgs = null;
 
-                    DataStore.LocalClients[ClientBody.ClientId] = new DVCLocalClientBuilder()
+                    DataStore.LocalClients[ClientBody.ClientId] = new DevCycleLocalClientBuilder()
                         .SetEnvironmentKey(ClientBody.SdkKey)
                         .SetInitializedSubscriber((o, e) =>
                         {
@@ -132,7 +132,7 @@ public class ClientController : ControllerBase
                             throw eventArgs.Errors[0];
                         }
                 } else {
-                    DataStore.LocalClients[ClientBody.ClientId] = new DVCLocalClientBuilder()
+                    DataStore.LocalClients[ClientBody.ClientId] = new DevCycleLocalClientBuilder()
                         .SetEnvironmentKey(ClientBody.SdkKey)
                         .SetOptions(ClientBody.Options)
                         .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))

--- a/proxies/dotnet/Controllers/Location.cs
+++ b/proxies/dotnet/Controllers/Location.cs
@@ -114,7 +114,7 @@ public class LocationController : ControllerBase
 
         foreach (var param in bodyParams) {
             if (param["type"]?.Value<string>() == "user") {
-                var sdkUser = new User(
+                var sdkUser = new DevCycleUser(
                     user.UserId,
                     user.Email,
                     user.Name,
@@ -134,7 +134,7 @@ public class LocationController : ControllerBase
                 );
                 result.Add(sdkUser);
             } else if (param["type"]?.Value<string>() == "event") {
-                var sdkEvent = new Event(
+                var sdkEvent = new DevCycleEvent(
                     reqEvent.Type,
                     reqEvent.Target,
                     reqEvent.Date,
@@ -169,9 +169,9 @@ public class LocationController : ControllerBase
 
         object? result = null;
         if (type == "client") {
-           if (DataStore.CloudClients.TryGetValue(id, out DVCCloudClient? cloudClient)) {
+           if (DataStore.CloudClients.TryGetValue(id, out DevCycleCloudClient? cloudClient)) {
                 result = cloudClient;
-           } else if (DataStore.LocalClients.TryGetValue(id, out DVCLocalClient? localClient)) {
+           } else if (DataStore.LocalClients.TryGetValue(id, out DevCycleLocalClient? localClient)) {
                 result = localClient;
            }
         } else if (type == "command" && DataStore.Commands.TryGetValue(id, out object? command)) {
@@ -185,7 +185,7 @@ public class LocationController : ControllerBase
 
     private async Task<CommandResult> InvokeCommand(object entity, string command, bool isAsync, List<object> parsedParams) {
         var parsedCommand = char.ToUpper(command[0]) + command.Substring(1);
-        parsedCommand = entity is DVCCloudClient ? parsedCommand + "Async" : parsedCommand;
+        parsedCommand = entity is DevCycleCloudClient ? parsedCommand + "Async" : parsedCommand;
 
         if (parsedCommand == "Close")
         {

--- a/proxies/dotnet/DataStore.cs
+++ b/proxies/dotnet/DataStore.cs
@@ -1,18 +1,17 @@
 using DevCycle.SDK.Server.Cloud.Api;
 using DevCycle.SDK.Server.Local.Api;
-using DevCycle.SDK.Server.Common.Model;
 
 class DataStore
 {
-    public static Dictionary<string, DVCLocalClient> LocalClients;
-    public static Dictionary<string, DVCCloudClient> CloudClients;
+    public static Dictionary<string, DevCycleLocalClient> LocalClients;
+    public static Dictionary<string, DevCycleCloudClient> CloudClients;
 
     public static Dictionary<string, object> Commands;
 
     static DataStore()
     {
-        CloudClients = new Dictionary<string, DVCCloudClient>();
-        LocalClients = new Dictionary<string, DVCLocalClient>();
+        CloudClients = new Dictionary<string, DevCycleCloudClient>();
+        LocalClients = new Dictionary<string, DevCycleLocalClient>();
         Commands = new Dictionary<string, object>();
     }
 }

--- a/proxies/dotnet/Models/ClientRequestEvent.cs
+++ b/proxies/dotnet/Models/ClientRequestEvent.cs
@@ -1,10 +1,6 @@
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
-using static DevCycle.SDK.Server.Common.Model.Event;
 
 [DataContract]
 public class ClientRequestEvent {

--- a/proxies/dotnet/Models/ClientRequestUser.cs
+++ b/proxies/dotnet/Models/ClientRequestUser.cs
@@ -1,10 +1,7 @@
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
-using static DevCycle.SDK.Server.Common.Model.User;
+using static DevCycle.SDK.Server.Common.Model.DevCycleUser;
 
 [DataContract]
 public class ClientRequestUser {


### PR DESCRIPTION
This updates the test harness to match the changes in this PR: https://github.com/DevCycleHQ/dotnet-server-sdk/pull/102

See [JIRA: DVC-8029](https://taplytics.atlassian.net/browse/DVC-8029)

Note: I have run these changes locally with the updated branch of the DotNet SDK and the test harness passes without errors. I'd like to merge this in first, event though it will be broken so that we can confirm the dotnet server sdk PR above passes before we merge