### PR TITLE
fix: Upgrade protobufjs via latest version of node SDKs

### DIFF
--- a/proxies/nodejs/handlers/location.ts
+++ b/proxies/nodejs/handlers/location.ts
@@ -4,7 +4,7 @@ import { getEntityFromType, DataStore, EntityTypes } from '../entityTypes'
 import { dataStore } from '../app'
 
 type RequestWithEntity = Koa.Request & {
-    entity: DevCycleClient | DevCycleUser | DVCVariable
+    entity: DevCycleClient | DevCycleUser | DVCVariable<any>
 }
 
 type Param = {
@@ -136,7 +136,7 @@ const parseParams = (body: LocationRequestBody, params: Param[], data: DataStore
 }
 
 const invokeCommand = (
-    entity: DevCycleClient | DevCycleUser | DVCVariable | any,
+    entity: DevCycleClient | DevCycleUser | DVCVariable<any> | any,
     command: string,
     params: ParsedParams,
 ) => {

--- a/proxies/nodejs/yarn.lock
+++ b/proxies/nodejs/yarn.lock
@@ -14,45 +14,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@devcycle/bucketing-assembly-script@npm:^1.7.2":
-  version: 1.7.2
-  resolution: "@devcycle/bucketing-assembly-script@npm:1.7.2"
-  checksum: 28ae132e2c986822bc35f95a7bafafcb0413ad3e4ab4eb9981f7c28fb6782f3cd988bb8d6d9bba26527384b0a02c5d8c9b442f38d25f3180d52a35a76c3b3603
+"@devcycle/bucketing-assembly-script@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "@devcycle/bucketing-assembly-script@npm:1.10.0"
+  dependencies:
+    protobufjs: ^7.2.5
+  checksum: 499d92886b480aff8dcf78e2fafe008d040cff3a5910cf1c3542bdd6d9ff86e4ed5d5d810581114f5f6b1e039d4ee7fc512e29cbfe32fd199f7588ff035461c3
   languageName: node
   linkType: hard
 
-"@devcycle/nodejs-server-sdk@npm:*":
-  version: 1.14.0
-  resolution: "@devcycle/nodejs-server-sdk@npm:1.14.0"
+"@devcycle/js-cloud-server-sdk@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@devcycle/js-cloud-server-sdk@npm:1.2.0"
   dependencies:
-    "@devcycle/bucketing-assembly-script": ^1.7.2
-    "@devcycle/types": 1.1.7
-    "@nestjs/class-validator": 0.13.4
-    class-transformer: 0.5.1
-    cross-fetch: ^3.1.5
+    "@devcycle/types": ^1.3.0
+    cross-fetch: ^3.1.8
     fetch-retry: ^5.0.3
-    iso-639-1: 2.1.13
     lodash: ^4.17.21
-    long: 5.2.1
-    moment: 2.29.4
-    murmurhash: 2.0.0
-    protobufjs: 7.2.2
-    reflect-metadata: 0.1.13
-    uuid: 8.3.2
-  checksum: d3b29e2cb760211d2898f14ee165eb57fa93365a516cd3409497bcaea759212f1a7b13de912e5efe86d93de242d62b589f1535dcee21283fd0bc590dcc18f72b
+  checksum: 9fba2901a67fb53de3322aa301b520e70351e7791b09d984ce0a437cb3007ec4cd8a32e4a7567baa691305122f5ddda0ebf22af1d47c0e692c67ad0c69685132
   languageName: node
   linkType: hard
 
-"@devcycle/types@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@devcycle/types@npm:1.1.7"
+"@devcycle/nodejs-server-sdk@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "@devcycle/nodejs-server-sdk@npm:1.17.0"
   dependencies:
-    "@nestjs/class-validator": 0.13.4
+    "@devcycle/bucketing-assembly-script": ^1.10.0
+    "@devcycle/js-cloud-server-sdk": ^1.2.0
+    "@devcycle/types": ^1.3.0
+    cross-fetch: ^3.1.8
+    fetch-retry: ^5.0.3
+  checksum: 6b9c569736647943d64adb952e38bbf6a4a7734f344a0ecb1d5efe984828af7fc81a566486de3815cb23765323ef62e7b5d148d5f12208b7885c5aa18f176e38
+  languageName: node
+  linkType: hard
+
+"@devcycle/types@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@devcycle/types@npm:1.3.0"
+  dependencies:
+    "@nestjs/class-validator": ^0.13.4
     class-transformer: 0.5.1
-    iso-639-1: 2.1.13
-    lodash: 4.17.21
-    reflect-metadata: 0.1.13
-  checksum: 96785afcce28036ab27098f6998ab58e9a24f88b9e79c9afc05d8bf95733e290e34f877c7e50b06cd7929622aa210bbf4ab810aff7b3b7eb0b34ce50d622c41d
+    iso-639-1: ^2.1.13
+    lodash: ^4.17.21
+    reflect-metadata: ^0.1.13
+  checksum: e98c52939ad11429f0b1d4e825d6d5e36781f418bb00e76df04824520908e5700c80ee3b1c39571f64ddc43cd40a642f80ade52f074515b96a8136c666cb01ac
   languageName: node
   linkType: hard
 
@@ -80,7 +85,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/class-validator@npm:0.13.4":
+"@nestjs/class-validator@npm:^0.13.4":
   version: 0.13.4
   resolution: "@nestjs/class-validator@npm:0.13.4"
   dependencies:
@@ -496,12 +501,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "cross-fetch@npm:3.1.5"
+"cross-fetch@npm:^3.1.8":
+  version: 3.1.8
+  resolution: "cross-fetch@npm:3.1.8"
   dependencies:
-    node-fetch: 2.6.7
-  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
+    node-fetch: ^2.6.12
+  checksum: 78f993fa099eaaa041122ab037fe9503ecbbcb9daef234d1d2e0b9230a983f64d645d088c464e21a247b825a08dc444a6e7064adfa93536d3a9454b4745b3632
   languageName: node
   linkType: hard
 
@@ -705,10 +710,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iso-639-1@npm:2.1.13":
-  version: 2.1.13
-  resolution: "iso-639-1@npm:2.1.13"
-  checksum: 53c0a76ad742b08dd1a5a525514f95457aa71aee4b9b71ad6bf8d5dc30b5db1cb9ec2dc3919ac6eb9b281c314a3e439b027760777e8c373068d38d003dd6812d
+"iso-639-1@npm:^2.1.13":
+  version: 2.1.15
+  resolution: "iso-639-1@npm:2.1.15"
+  checksum: a201530819d33e9ce077b02c786d67b35be5d823be27b5aacc18d880e580e559e39ec5055f8e2abcdc210f46618a643bf3c74e6fe6e8255fe62059682750e595
   languageName: node
   linkType: hard
 
@@ -798,17 +803,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
-  languageName: node
-  linkType: hard
-
-"long@npm:5.2.1":
-  version: 5.2.1
-  resolution: "long@npm:5.2.1"
-  checksum: 9264da12d1b7df67e5aa6da4498144293caf1ad12e7f092efe4e9a2d32c53f0bbf7334f7cef997080a2a3af061142558ab366efa71698d98b1cdb883477445a7
   languageName: node
   linkType: hard
 
@@ -856,24 +854,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:2.29.4":
-  version: 2.29.4
-  resolution: "moment@npm:2.29.4"
-  checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
-  languageName: node
-  linkType: hard
-
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
   checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
-  languageName: node
-  linkType: hard
-
-"murmurhash@npm:2.0.0":
-  version: 2.0.0
-  resolution: "murmurhash@npm:2.0.0"
-  checksum: 01546111bea9699e5241b29397a7d9569f3b75aa417dc492a06e7b075b98657cef05b2c560f534770ed5822ed6556333b3d7935b3f275a80332d9417e4944ecd
   languageName: node
   linkType: hard
 
@@ -884,9 +868,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.7":
-  version: 2.6.7
-  resolution: "node-fetch@npm:2.6.7"
+"node-fetch@npm:^2.6.12":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
   dependencies:
     whatwg-url: ^5.0.0
   peerDependencies:
@@ -894,7 +878,7 @@ __metadata:
   peerDependenciesMeta:
     encoding:
       optional: true
-  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 
@@ -935,9 +919,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.2.2":
-  version: 7.2.2
-  resolution: "protobufjs@npm:7.2.2"
+"protobufjs@npm:^7.2.5":
+  version: 7.2.5
+  resolution: "protobufjs@npm:7.2.5"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -951,7 +935,7 @@ __metadata:
     "@protobufjs/utf8": ^1.1.0
     "@types/node": ">=13.7.0"
     long: ^5.0.0
-  checksum: 86166e8f3e46789fa4d117ae72c17356db36bf87c0e0710d224be32e543b1c378a94e66dc2b1de5af45edfc25f56acfc7e688c50c956426a3ae97bc474f4445c
+  checksum: 3770a072114061faebbb17cfd135bc4e187b66bc6f40cd8bac624368b0270871ec0cfb43a02b9fb4f029c8335808a840f1afba3c2e7ede7063b98ae6b98a703f
   languageName: node
   linkType: hard
 
@@ -976,7 +960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reflect-metadata@npm:0.1.13":
+"reflect-metadata@npm:^0.1.13":
   version: 0.1.13
   resolution: "reflect-metadata@npm:0.1.13"
   checksum: 798d379a7b6f6455501145419505c97dd11cbc23857a386add2b9ef15963ccf15a48d9d15507afe01d4cd74116df8a213247200bac00320bd7c11ddeaa5e8fb4
@@ -987,7 +971,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@devcycle/nodejs-server-sdk": "*"
+    "@devcycle/nodejs-server-sdk": ^1.17.0
     "@types/koa": ^2.13.5
     "@types/koa-bodyparser": ^4.3.10
     "@types/koa-router": ^7.4.4
@@ -1138,15 +1122,6 @@ __metadata:
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
-  languageName: node
-  linkType: hard
-
-"uuid@npm:8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 

--- a/proxies/openfeature-nodejs/handlers/location.ts
+++ b/proxies/openfeature-nodejs/handlers/location.ts
@@ -16,7 +16,7 @@ import { getEntityFromType, DataStore, EntityTypes, DataStoreClient } from '../e
 import { dataStore } from '../app'
 
 type RequestWithEntity = Koa.Request & {
-    entity: DataStoreClient | DevCycleUser | DVCVariableInterface
+    entity: DataStoreClient | DevCycleUser | DVCVariableInterface<any>
 }
 
 type Param = {
@@ -182,7 +182,7 @@ const getOpenFeatureVariable = async (
 const getOpenFeatureVariableValue = async (
     openFeatureClient: OFClient,
     params: any[]
-): Promise<DVCVariableInterface['value']> => {
+): Promise<DVCVariableInterface<any>['value']> => {
     const [user, key, defaultValue, type] = params
     if (type === 'boolean') {
         return await openFeatureClient.getBooleanValue(key, defaultValue as boolean, user)
@@ -200,13 +200,13 @@ const getOpenFeatureVariableValue = async (
 /**
  * Fake DVCVariable Class so that the variable type reporting works correctly
   */
-class DVCVariable implements DVCVariableInterface {
+class DVCVariable implements DVCVariableInterface<any> {
     constructor(
         public key: string,
-        public value: DVCVariableInterface['value'],
-        public defaultValue: DVCVariableInterface['value'],
-        public isDefaulted: DVCVariableInterface['isDefaulted'],
-        public type: DVCVariableInterface['type']
+        public value: DVCVariableInterface<any>['value'],
+        public defaultValue: DVCVariableInterface<any>['value'],
+        public isDefaulted: DVCVariableInterface<any>['isDefaulted'],
+        public type: DVCVariableInterface<any>['type']
     ) {}
 }
 

--- a/proxies/openfeature-nodejs/yarn.lock
+++ b/proxies/openfeature-nodejs/yarn.lock
@@ -14,69 +14,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@devcycle/bucketing-assembly-script@npm:1.7.2, @devcycle/bucketing-assembly-script@npm:^1.7.2":
-  version: 1.7.2
-  resolution: "@devcycle/bucketing-assembly-script@npm:1.7.2"
-  checksum: 28ae132e2c986822bc35f95a7bafafcb0413ad3e4ab4eb9981f7c28fb6782f3cd988bb8d6d9bba26527384b0a02c5d8c9b442f38d25f3180d52a35a76c3b3603
+"@devcycle/bucketing-assembly-script@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "@devcycle/bucketing-assembly-script@npm:1.10.0"
+  dependencies:
+    protobufjs: ^7.2.5
+  checksum: 499d92886b480aff8dcf78e2fafe008d040cff3a5910cf1c3542bdd6d9ff86e4ed5d5d810581114f5f6b1e039d4ee7fc512e29cbfe32fd199f7588ff035461c3
   languageName: node
   linkType: hard
 
-"@devcycle/nodejs-server-sdk@npm:1.14.0":
-  version: 1.14.0
-  resolution: "@devcycle/nodejs-server-sdk@npm:1.14.0"
+"@devcycle/js-cloud-server-sdk@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@devcycle/js-cloud-server-sdk@npm:1.2.0"
   dependencies:
-    "@devcycle/bucketing-assembly-script": ^1.7.2
-    "@devcycle/types": 1.1.7
-    "@nestjs/class-validator": 0.13.4
-    class-transformer: 0.5.1
-    cross-fetch: ^3.1.5
+    "@devcycle/types": ^1.3.0
+    cross-fetch: ^3.1.8
     fetch-retry: ^5.0.3
-    iso-639-1: 2.1.13
     lodash: ^4.17.21
-    long: 5.2.1
-    moment: 2.29.4
-    murmurhash: 2.0.0
-    protobufjs: 7.2.2
-    reflect-metadata: 0.1.13
-    uuid: 8.3.2
-  checksum: d3b29e2cb760211d2898f14ee165eb57fa93365a516cd3409497bcaea759212f1a7b13de912e5efe86d93de242d62b589f1535dcee21283fd0bc590dcc18f72b
+  checksum: 9fba2901a67fb53de3322aa301b520e70351e7791b09d984ce0a437cb3007ec4cd8a32e4a7567baa691305122f5ddda0ebf22af1d47c0e692c67ad0c69685132
+  languageName: node
+  linkType: hard
+
+"@devcycle/nodejs-server-sdk@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "@devcycle/nodejs-server-sdk@npm:1.17.0"
+  dependencies:
+    "@devcycle/bucketing-assembly-script": ^1.10.0
+    "@devcycle/js-cloud-server-sdk": ^1.2.0
+    "@devcycle/types": ^1.3.0
+    cross-fetch: ^3.1.8
+    fetch-retry: ^5.0.3
+  checksum: 6b9c569736647943d64adb952e38bbf6a4a7734f344a0ecb1d5efe984828af7fc81a566486de3815cb23765323ef62e7b5d148d5f12208b7885c5aa18f176e38
   languageName: node
   linkType: hard
 
 "@devcycle/openfeature-nodejs-provider@npm:*":
-  version: 1.2.0
-  resolution: "@devcycle/openfeature-nodejs-provider@npm:1.2.0"
+  version: 1.5.0
+  resolution: "@devcycle/openfeature-nodejs-provider@npm:1.5.0"
   dependencies:
-    "@devcycle/bucketing-assembly-script": 1.7.2
-    "@devcycle/nodejs-server-sdk": 1.14.0
-    "@devcycle/types": 1.1.7
-    "@nestjs/class-validator": 0.13.4
-    "@openfeature/js-sdk": ^1.3.1
-    class-transformer: 0.5.1
-    cross-fetch: 3.1.5
-    fetch-retry: 5.0.3
-    iso-639-1: 2.1.13
-    lodash: 4.17.21
-    long: 5.2.1
-    moment: 2.29.4
-    murmurhash: 2.0.0
-    protobufjs: 7.2.2
-    reflect-metadata: 0.1.13
-    uuid: 8.3.2
-  checksum: 021965dcea0b50710dc55d1ca3ab5cc9448a13e1b36940ffab141675469716154d24f31db4949f1c65378da37736a06a4aea85c8c933fe8fbdc22da0c16d9d90
+    "@devcycle/nodejs-server-sdk": ^1.17.0
+    "@devcycle/types": ^1.3.0
+    "@openfeature/js-sdk": ^1.4.2
+  checksum: 99903673c8d2c51a8d15b583e7821273378655a8e7dc5e57701c49e87b67d4a52e695a2b329439a699113ccad03bc198cd32cc8aa6751d7c82b8a998326e0462
   languageName: node
   linkType: hard
 
-"@devcycle/types@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@devcycle/types@npm:1.1.7"
+"@devcycle/types@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@devcycle/types@npm:1.3.0"
   dependencies:
-    "@nestjs/class-validator": 0.13.4
+    "@nestjs/class-validator": ^0.13.4
     class-transformer: 0.5.1
-    iso-639-1: 2.1.13
-    lodash: 4.17.21
-    reflect-metadata: 0.1.13
-  checksum: 96785afcce28036ab27098f6998ab58e9a24f88b9e79c9afc05d8bf95733e290e34f877c7e50b06cd7929622aa210bbf4ab810aff7b3b7eb0b34ce50d622c41d
+    iso-639-1: ^2.1.13
+    lodash: ^4.17.21
+    reflect-metadata: ^0.1.13
+  checksum: e98c52939ad11429f0b1d4e825d6d5e36781f418bb00e76df04824520908e5700c80ee3b1c39571f64ddc43cd40a642f80ade52f074515b96a8136c666cb01ac
   languageName: node
   linkType: hard
 
@@ -104,7 +96,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/class-validator@npm:0.13.4":
+"@nestjs/class-validator@npm:^0.13.4":
   version: 0.13.4
   resolution: "@nestjs/class-validator@npm:0.13.4"
   dependencies:
@@ -121,10 +113,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openfeature/js-sdk@npm:^1.3.1":
-  version: 1.3.3
-  resolution: "@openfeature/js-sdk@npm:1.3.3"
-  checksum: ada17d8957a4bdd27becfb26940c57afd722dc2ae7efa2db29b20a792afae000a6c890b527934fd6e9ffb75426635c2a44cac9b66d52320435005cbbb246d9e9
+"@openfeature/js-sdk@npm:^1.4.2":
+  version: 1.6.1
+  resolution: "@openfeature/js-sdk@npm:1.6.1"
+  checksum: ef4e7c373d16645ed0cc1d1a85e087b28d10bc2ba0c967cf7ac3fad2515dc2fd9a775ced8ab5ae35271b70e8102375950bb4368a17398e898990f50e92d82881
   languageName: node
   linkType: hard
 
@@ -534,12 +526,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:3.1.5, cross-fetch@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "cross-fetch@npm:3.1.5"
+"cross-fetch@npm:^3.1.8":
+  version: 3.1.8
+  resolution: "cross-fetch@npm:3.1.8"
   dependencies:
-    node-fetch: 2.6.7
-  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
+    node-fetch: ^2.6.12
+  checksum: 78f993fa099eaaa041122ab037fe9503ecbbcb9daef234d1d2e0b9230a983f64d645d088c464e21a247b825a08dc444a6e7064adfa93536d3a9454b4745b3632
   languageName: node
   linkType: hard
 
@@ -615,13 +607,6 @@ __metadata:
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
-  languageName: node
-  linkType: hard
-
-"fetch-retry@npm:5.0.3":
-  version: 5.0.3
-  resolution: "fetch-retry@npm:5.0.3"
-  checksum: b4eebc04bd41651417e89ae9287e5b9e5421970ce07058c6e1e22f7d9c1cd5f935fc39a328fd66b433247c0ae1bb8a6b2d48c073d5a9f911992f72c5d311b14d
   languageName: node
   linkType: hard
 
@@ -750,10 +735,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iso-639-1@npm:2.1.13":
-  version: 2.1.13
-  resolution: "iso-639-1@npm:2.1.13"
-  checksum: 53c0a76ad742b08dd1a5a525514f95457aa71aee4b9b71ad6bf8d5dc30b5db1cb9ec2dc3919ac6eb9b281c314a3e439b027760777e8c373068d38d003dd6812d
+"iso-639-1@npm:^2.1.13":
+  version: 2.1.15
+  resolution: "iso-639-1@npm:2.1.15"
+  checksum: a201530819d33e9ce077b02c786d67b35be5d823be27b5aacc18d880e580e559e39ec5055f8e2abcdc210f46618a643bf3c74e6fe6e8255fe62059682750e595
   languageName: node
   linkType: hard
 
@@ -843,17 +828,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
-  languageName: node
-  linkType: hard
-
-"long@npm:5.2.1":
-  version: 5.2.1
-  resolution: "long@npm:5.2.1"
-  checksum: 9264da12d1b7df67e5aa6da4498144293caf1ad12e7f092efe4e9a2d32c53f0bbf7334f7cef997080a2a3af061142558ab366efa71698d98b1cdb883477445a7
   languageName: node
   linkType: hard
 
@@ -901,24 +879,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:2.29.4":
-  version: 2.29.4
-  resolution: "moment@npm:2.29.4"
-  checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
-  languageName: node
-  linkType: hard
-
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
   checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
-  languageName: node
-  linkType: hard
-
-"murmurhash@npm:2.0.0":
-  version: 2.0.0
-  resolution: "murmurhash@npm:2.0.0"
-  checksum: 01546111bea9699e5241b29397a7d9569f3b75aa417dc492a06e7b075b98657cef05b2c560f534770ed5822ed6556333b3d7935b3f275a80332d9417e4944ecd
   languageName: node
   linkType: hard
 
@@ -929,9 +893,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.7":
-  version: 2.6.7
-  resolution: "node-fetch@npm:2.6.7"
+"node-fetch@npm:^2.6.12":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
   dependencies:
     whatwg-url: ^5.0.0
   peerDependencies:
@@ -939,7 +903,7 @@ __metadata:
   peerDependenciesMeta:
     encoding:
       optional: true
-  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 
@@ -980,9 +944,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.2.2":
-  version: 7.2.2
-  resolution: "protobufjs@npm:7.2.2"
+"protobufjs@npm:^7.2.5":
+  version: 7.2.5
+  resolution: "protobufjs@npm:7.2.5"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -996,7 +960,7 @@ __metadata:
     "@protobufjs/utf8": ^1.1.0
     "@types/node": ">=13.7.0"
     long: ^5.0.0
-  checksum: 86166e8f3e46789fa4d117ae72c17356db36bf87c0e0710d224be32e543b1c378a94e66dc2b1de5af45edfc25f56acfc7e688c50c956426a3ae97bc474f4445c
+  checksum: 3770a072114061faebbb17cfd135bc4e187b66bc6f40cd8bac624368b0270871ec0cfb43a02b9fb4f029c8335808a840f1afba3c2e7ede7063b98ae6b98a703f
   languageName: node
   linkType: hard
 
@@ -1021,7 +985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reflect-metadata@npm:0.1.13":
+"reflect-metadata@npm:^0.1.13":
   version: 0.1.13
   resolution: "reflect-metadata@npm:0.1.13"
   checksum: 798d379a7b6f6455501145419505c97dd11cbc23857a386add2b9ef15963ccf15a48d9d15507afe01d4cd74116df8a213247200bac00320bd7c11ddeaa5e8fb4
@@ -1184,15 +1148,6 @@ __metadata:
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
-  languageName: node
-  linkType: hard
-
-"uuid@npm:8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I installed the latest `@devcycle/nodejs-server-sdk` and `@devcycle/openfeature-nodejs-provider`, which pulled in new versions of `protobufjs`. I switched the versions in the package.json files back to `*` instead of specific versions so we don't have to keep bumping it for testing test harness changes.

I also fixed a few small type signature issues in the proxies for nodejs and of-nodejs.