### PR TITLE
rename to client sdk key

### DIFF
--- a/harness/features/bootstrapping.test.ts
+++ b/harness/features/bootstrapping.test.ts
@@ -50,7 +50,7 @@ describe('Bootstrapping Tests', () => {
                         'features.0.variations.0.variables.1.value',
                         'new string',
                     ),
-                    sdkKey: 'client-key',
+                    clientSDKKey: 'client-key',
                 }
 
                 scope
@@ -83,7 +83,7 @@ describe('Bootstrapping Tests', () => {
                 expect(configResult.data.variables['string-var'].value).toEqual(
                     'new string',
                 )
-                expect(configResult.data.sdkKey).toEqual('client-key')
+                expect(configResult.data.clientSDKKey).toEqual('client-key')
             })
         })
     })


### PR DESCRIPTION
The field name was wrong in the tests, the actual name being used by the config service is `clientSDKKey`