### PR TITLE
chore: cleanup events capability supported by all SDKs

### DIFF
--- a/harness/features/clientCustomData.test.ts
+++ b/harness/features/clientCustomData.test.ts
@@ -21,11 +21,7 @@ describe('Client Custom Data Tests', () => {
                 )
                 .reply(200, config)
 
-            if (hasCapability(sdkName, Capabilities.events)) {
-                scope
-                    .post(`/client/${client.clientId}/v1/events/batch`)
-                    .reply(201)
-            }
+            scope.post(`/client/${client.clientId}/v1/events/batch`).reply(201)
 
             const customData = { 'should-bucket': true }
             await client.createClient(true)
@@ -71,11 +67,7 @@ describe('Client Custom Data Tests', () => {
                 'Config request timed out',
             )
 
-            if (hasCapability(sdkName, Capabilities.events)) {
-                scope
-                    .post(`/client/${client.clientId}/v1/events/batch`)
-                    .reply(201)
-            }
+            scope.post(`/client/${client.clientId}/v1/events/batch`).reply(201)
 
             const response = await client.callVariable(
                 { user_id: 'user-id' },

--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -103,22 +103,39 @@ describe('Initialize Tests - Local', () => {
             const testClient = new LocalTestClient(sdkName)
 
             scope
-                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .get(
+                    `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`,
+                )
                 .times(2)
                 .reply(500)
-            if (hasCapability(sdkName, Capabilities.events)) {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/events/batch`)
-                    .reply(201)
-            }
-            await testClient.createClient(true, { configPollingIntervalMS: 3000 })
             scope
-                .get(`/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`)
+                .post(`/client/${testClient.clientId}/v1/events/batch`)
+                .reply(201)
+
+            await testClient.createClient(true, {
+                configPollingIntervalMS: 3000,
+            })
+            scope
+                .get(
+                    `/client/${testClient.clientId}/config/v1/server/${testClient.sdkKey}.json`,
+                )
                 .reply(200, config)
-            const variable = await testClient.callVariable(shouldBucketUser, sdkName, 'number-var', 'number', 0)
+            const variable = await testClient.callVariable(
+                shouldBucketUser,
+                sdkName,
+                'number-var',
+                'number',
+                0,
+            )
             expect((await variable.json()).data.value).toEqual(0)
             await wait(3100)
-            const variable2 = await testClient.callVariable(shouldBucketUser, sdkName, 'number-var', 'number', 0)
+            const variable2 = await testClient.callVariable(
+                shouldBucketUser,
+                sdkName,
+                'number-var',
+                'number',
+                0,
+            )
             expect((await variable2.json()).data.value).toEqual(1)
         })
 
@@ -215,11 +232,9 @@ describe('Initialize Tests - Local', () => {
             await wait(1100)
             expect(scope.pendingMocks().length).toEqual(0)
 
-            if (hasCapability(sdkName, Capabilities.events)) {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/events/batch`)
-                    .reply(201)
-            }
+            scope
+                .post(`/client/${testClient.clientId}/v1/events/batch`)
+                .reply(201)
 
             // make sure the original config is still in use
             const variable = await testClient.callVariable(
@@ -257,11 +272,10 @@ describe('Initialize Tests - Local', () => {
             await wait(1500)
             expect(scope.pendingMocks().length).toEqual(0)
             // make sure the original config is still in use
-            if (hasCapability(sdkName, Capabilities.events)) {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/events/batch`)
-                    .reply(201)
-            }
+            scope
+                .post(`/client/${testClient.clientId}/v1/events/batch`)
+                .reply(201)
+
             const variable = await testClient.callVariable(
                 shouldBucketUser,
                 sdkName,
@@ -295,11 +309,10 @@ describe('Initialize Tests - Local', () => {
             await wait(1200)
             expect(scope.pendingMocks().length).toEqual(0)
             // make sure the original config is still in use
-            if (hasCapability(sdkName, Capabilities.events)) {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/events/batch`)
-                    .reply(201)
-            }
+            scope
+                .post(`/client/${testClient.clientId}/v1/events/batch`)
+                .reply(201)
+
             const variable = await testClient.callVariable(
                 shouldBucketUser,
                 sdkName,
@@ -337,11 +350,10 @@ describe('Initialize Tests - Local', () => {
             await wait(1200)
             expect(scope.pendingMocks().length).toEqual(0)
             // make sure the original config is still in use
-            if (hasCapability(sdkName, Capabilities.events)) {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/events/batch`)
-                    .reply(201)
-            }
+            scope
+                .post(`/client/${testClient.clientId}/v1/events/batch`)
+                .reply(201)
+
             const variable = await testClient.callVariable(
                 shouldBucketUser,
                 sdkName,

--- a/harness/features/track.local.test.ts
+++ b/harness/features/track.local.test.ts
@@ -23,11 +23,7 @@ describe('Track Tests - Local', () => {
 
     const eventFlushIntervalMS = 1000
 
-    describeCapability(
-        sdkName,
-        Capabilities.local,
-        Capabilities.events,
-    )(sdkName, () => {
+    describeCapability(sdkName, Capabilities.local)(sdkName, () => {
         let client: LocalTestClient
         let sdkConfigEventBatch
 

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -155,10 +155,6 @@ describe('Variable Tests - Local', () => {
                             },
                         })
 
-                        if (!hasCapability(sdkName, Capabilities.events)) {
-                            return
-                        }
-
                         // waits for the request to the events API
                         await eventResult.wait()
 
@@ -215,10 +211,6 @@ describe('Variable Tests - Local', () => {
                                 : VariableType.number,
                         )
 
-                        if (!hasCapability(sdkName, Capabilities.events)) {
-                            return
-                        }
-
                         await eventResult.wait()
 
                         // Expects that the SDK sends an "aggVariableDefaulted" event for the
@@ -273,10 +265,6 @@ describe('Variable Tests - Local', () => {
                             variableType,
                         )
 
-                        if (!hasCapability(sdkName, Capabilities.events)) {
-                            return
-                        }
-
                         await eventResult.wait()
 
                         expectAggregateDefaultEvent({
@@ -321,10 +309,6 @@ describe('Variable Tests - Local', () => {
                             variableType,
                         )
 
-                        if (!hasCapability(sdkName, Capabilities.events)) {
-                            return
-                        }
-
                         await eventResult.wait()
 
                         expectAggregateDefaultEvent({
@@ -367,10 +351,6 @@ describe('Variable Tests - Local', () => {
                             type,
                             defaultValue,
                         )
-
-                        if (!hasCapability(sdkName, Capabilities.events)) {
-                            return
-                        }
 
                         await eventResult.wait()
                         expectAggregateDefaultEvent({
@@ -415,9 +395,6 @@ describe('Variable Tests - Local', () => {
                             defaultValue,
                         )
 
-                        if (!hasCapability(sdkName, Capabilities.events)) {
-                            return
-                        }
                         await eventResult.wait()
                         expectAggregateEvaluationEvent({
                             body: eventResult.body,
@@ -466,10 +443,6 @@ describe('Variable Tests - Local', () => {
                         },
                         logs: [],
                     })
-
-                    if (!hasCapability(sdkName, Capabilities.events)) {
-                        return
-                    }
 
                     await eventResult.wait()
                     expectAggregateEvaluationEvent({
@@ -537,10 +510,6 @@ describe('Variable Tests - Local', () => {
                             variableType,
                         )
 
-                        if (!hasCapability(sdkName, Capabilities.events)) {
-                            return
-                        }
-
                         await eventResult.wait()
                         expectAggregateDefaultEvent({
                             body: eventResult.body,
@@ -602,10 +571,6 @@ describe('Variable Tests - Local', () => {
                             defaultValue,
                             variableType,
                         )
-
-                        if (!hasCapability(sdkName, Capabilities.events)) {
-                            return
-                        }
 
                         await eventResult.wait()
                         expectAggregateDefaultEvent({

--- a/harness/helpers/events.ts
+++ b/harness/helpers/events.ts
@@ -217,9 +217,6 @@ export const interceptEvents = (
     sdkName: string,
     eventsUrl: string,
 ) => {
-    if (!hasCapability(sdkName, Capabilities.events)) {
-        return
-    }
     // The interceptor instance is used to wait on events that are triggered when calling
     // methods so that we can verify events being sent out and mock out responses from the
     // event server

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -1,6 +1,5 @@
 export const Capabilities = {
     edgeDB: 'EdgeDB',
-    events: 'Events',
     local: 'LocalBucketing',
     cloud: 'CloudBucketing',
     sse: 'SSE',
@@ -18,7 +17,6 @@ export const Capabilities = {
 
 export const SDKCapabilities = {
     NodeJS: [
-        Capabilities.events,
         Capabilities.edgeDB,
         Capabilities.local,
         Capabilities.cloud,
@@ -29,7 +27,6 @@ export const SDKCapabilities = {
         Capabilities.clientUUID,
     ],
     'OF-NodeJS': [
-        Capabilities.events,
         Capabilities.edgeDB,
         Capabilities.local,
         Capabilities.cloud,
@@ -39,7 +36,6 @@ export const SDKCapabilities = {
         Capabilities.clientUUID,
     ],
     Python: [
-        Capabilities.events,
         Capabilities.cloud,
         Capabilities.local,
         Capabilities.edgeDB,
@@ -47,7 +43,6 @@ export const SDKCapabilities = {
         Capabilities.variableValue,
     ],
     DotNet: [
-        Capabilities.events,
         Capabilities.cloud,
         Capabilities.local,
         Capabilities.edgeDB,
@@ -55,7 +50,6 @@ export const SDKCapabilities = {
         Capabilities.variableValue,
     ],
     Java: [
-        Capabilities.events,
         Capabilities.cloud,
         Capabilities.local,
         Capabilities.edgeDB,
@@ -63,7 +57,6 @@ export const SDKCapabilities = {
         Capabilities.variableValue,
     ],
     Go: [
-        Capabilities.events,
         Capabilities.cloud,
         Capabilities.local,
         Capabilities.edgeDB,
@@ -75,10 +68,9 @@ export const SDKCapabilities = {
         Capabilities.lastModifiedHeader,
     ],
     Ruby: [
-        Capabilities.events,
         Capabilities.local,
         Capabilities.clientCustomData,
         Capabilities.variableValue,
     ],
-    PHP: [Capabilities.events, Capabilities.local, Capabilities.cloudProxy],
+    PHP: [Capabilities.local, Capabilities.cloudProxy],
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
