### PR TITLE
 Fixes for the SDKConfig Event; Featurevars is not required.

### DIFF
--- a/harness/features/multithreading.local.test.ts
+++ b/harness/features/multithreading.local.test.ts
@@ -380,6 +380,7 @@ describe('Multithreading Tests', () => {
                     etag: null,
                     rayId: null,
                     lastModified: null,
+                    skipSDKConfigEvent: true
                 })
             })
         })

--- a/harness/features/track.local.test.ts
+++ b/harness/features/track.local.test.ts
@@ -135,7 +135,8 @@ describe('Track Tests - Local', () => {
             )
 
             expect(eventBody).toEqual({
-                batch: [
+                batch: expect.arrayContaining([
+
                     ...(hasCapability(sdkName, Capabilities.sdkConfigEvent)
                         ? [sdkConfigEventBatch]
                         : []),
@@ -162,7 +163,7 @@ describe('Track Tests - Local', () => {
                             },
                         ],
                     },
-                ],
+                ]),
             })
         })
 

--- a/harness/helpers/events.ts
+++ b/harness/helpers/events.ts
@@ -28,10 +28,10 @@ const addSDKConfigEventBatch = (sdkName: string, expectedPlatform: string) => {
                           type: 'sdkConfig',
                           target: expect.any(String),
                           value: expect.any(Number),
-                          featureVars: {
+                          featureVars: expect.toBeOneOf([{
                               '6386813a59f1b81cc9e6c68d':
                                   '6386813a59f1b81cc9e6c693',
-                          },
+                          }, {}]),
                           metaData: expect.objectContaining({
                               clientUUID: expect.any(String),
                               resStatus: 200,
@@ -182,7 +182,7 @@ export const expectAggregateDefaultEvent = ({
     }
 
     expect(body).toEqual({
-        batch: expect.toIncludeSameMembers([
+        batch: expect.arrayContaining([
             ...optionalSDKConfigNewUser,
             {
                 user: {
@@ -191,7 +191,7 @@ export const expectAggregateDefaultEvent = ({
                     platform: expectedPlatform,
                     sdkType: 'server',
                 },
-                events: expect.toIncludeSameMembers([
+                events: expect.arrayContaining([
                     ...optionalSDKConfigNewEvent,
                     {
                         ...optionalEventFields,

--- a/proxies/go/go.mod
+++ b/proxies/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/devcyclehq/test-harness/proxies/go
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/devcyclehq/go-server-sdk/v2 v2.14.0


### PR DESCRIPTION
- The default check should not expect an sdkconfig event - the delay is set to 2 seconds - when the flush is 500ms
- Track needs to use arraycontaining
- Fix go.mod version

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses several issues related to the SDKConfig event handling and test configurations. It fixes the default check for sdkConfig events, updates the go.mod version, and refines test cases to improve event matching and handling.

* **Bug Fixes**:
    - Fixed the default check to not expect an sdkConfig event by default, adjusting the delay to 2 seconds and the flush to 500ms.
    - Corrected the use of arrayContaining in the Track function to ensure proper event handling.
* **Enhancements**:
    - Updated the go.mod file to use version 1.22.2.
* **Tests**:
    - Modified test cases to use expect.arrayContaining instead of expect.toIncludeSameMembers for better flexibility in event matching.
    - Added skipSDKConfigEvent flag in multithreading tests to bypass unnecessary sdkConfig event checks.

<!-- Generated by sourcery-ai[bot]: end summary -->