### PR TITLE
Improve etag test

### DIFF
--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -350,7 +350,7 @@ describe('Initialize Tests - Local', () => {
         )
 
         await testClient.createClient(true, {
-            configPollingIntervalMS: 2000,
+            configPollingIntervalMS: 1000,
             eventFlushIntervalMS: 500,
         })
 

--- a/harness/helpers/helpers.ts
+++ b/harness/helpers/helpers.ts
@@ -192,13 +192,9 @@ export const waitForRequest = async (
         return
     }
 
-    const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => {
-            reject(new Error(timeoutMessage))
-        }, timeout)
-    })
-
     let callback
+
+    const timeoutError = new Error(timeoutMessage)
 
     await Promise.race([
         new Promise((resolve) => {
@@ -211,7 +207,11 @@ export const waitForRequest = async (
             }
             scope.on('request', callback)
         }),
-        timeoutPromise,
+        new Promise((_, reject) => {
+            setTimeout(() => {
+                reject(timeoutError)
+            }, timeout)
+        }),
     ]).finally(() => {
         scope.off('request', callback)
     })
@@ -283,7 +283,7 @@ export class LocalTestClient extends BaseTestClient {
             this.setupMockConfig(scope)
         }
     }
-    
+
     async createClient(
         waitForInitialization: boolean,
         options: ProxyClientOptions = {},

--- a/harness/mockServer/index.ts
+++ b/harness/mockServer/index.ts
@@ -51,6 +51,7 @@ export function initialize() {
                 'Forwarding Request to Nock Server: ',
                 request.method,
                 ctx.request.url,
+                ctx.request.headers,
             )
         }
 


### PR DESCRIPTION
- wait for config requests rather than arbitrary amounts of time
- remove redundant config request handlers that should never be triggered given the setup for the test
- remove `.times(1)` specifier as it is redundant
- fix stack trace for errors thrown from event handler timeout so its possible to find which event call triggered the error
- add headers to request debug log