### PR TITLE
Only throw errors if they exist 

### DIFF
--- a/proxies/dotnet/Controllers/Client.cs
+++ b/proxies/dotnet/Controllers/Client.cs
@@ -128,7 +128,7 @@ public class ClientController : ControllerBase
                         .Build();
 
                         await task;
-                        if (eventArgs != null && !eventArgs.Success) {
+                        if (eventArgs != null && eventArgs.Errors.Count > 0) {
                             throw eventArgs.Errors[0];
                         }
                 } else {


### PR DESCRIPTION
not if the initialization is delayed intentionally

Without this you'll get a concurrent error exception/out of bounds.
