### PR TITLE
chore: Fix timeout delay

### DIFF
--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -92,7 +92,7 @@ describe('Initialize Tests - Local', () => {
         scope.post(`/client/${testClient.clientId}/v1/events/batch`).reply(201)
 
         await testClient.createClient(true, {
-            configPollingIntervalMS: 3000,
+            configPollingIntervalMS: 1000,
         })
         scope
             .get(configRequestUrl)

--- a/harness/features/initialize.local.test.ts
+++ b/harness/features/initialize.local.test.ts
@@ -105,7 +105,7 @@ describe('Initialize Tests - Local', () => {
             0,
         )
         expect((await variable.json()).data.value).toEqual(0)
-        await wait(3100)
+        await wait(1100)
         const variable2 = await testClient.callVariable(
             shouldBucketUser,
             sdkName,


### PR DESCRIPTION
Timeouts on each SDK for the request/retries are different - so this sets it below them all. 

The timeouts cause a race condition based on the number of tests running/the requests handled.