### PR TITLE
Fix code scanning alert no. 46: Log Injection

### DIFF
--- a/proxies/python/handlers/command.py
+++ b/proxies/python/handlers/command.py
@@ -66,9 +66,10 @@ def handle_command(path, body, data_store):
             "message": "Invalid request: missing command"
         }, 400
 
-    command = snake_case(command)
+    command = snake_case(command).replace('\r\n', '').replace('\n', '')
+    sanitized_params = [str(param).replace('\r\n', '').replace('\n', '') for param in parsed_params]
 
-    logger.info("[COMMAND] " + command + " " + str(parsed_params))
+    logger.info("[COMMAND] " + command + " " + str(sanitized_params))
 
     result = invoke_command(stored_entity, command, parsed_params)
 


### PR DESCRIPTION
Fixes [https://github.com/DevCycleHQ/test-harness/security/code-scanning/46](https://github.com/DevCycleHQ/test-harness/security/code-scanning/46)

To fix the log injection issue, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the `command` and `parsed_params` variables to prevent log injection. We can use the `replace` method to achieve this.

1. Sanitize the `command` variable by replacing newline characters with empty strings.
2. Sanitize each element in the `parsed_params` list by replacing newline characters with empty strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
