### PR TITLE
Test-harness-version

### DIFF
--- a/proxies/go/Dockerfile
+++ b/proxies/go/Dockerfile
@@ -1,6 +1,6 @@
 # reference https://github.com/docker-library/golang/issues/209#issuecomment-530591780
 
-FROM golang:1.22.2 as builder
+FROM golang as builder
 
 ARG GO_SDK_VERSION
 ENV GO_SDK_VERSION $GO_SDK_VERSION

--- a/proxies/go/go.mod
+++ b/proxies/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/devcyclehq/test-harness/proxies/go
 
-go 1.22.2
+go 1.23.0
 
 require (
 	github.com/devcyclehq/go-server-sdk/v2 v2.19.0


### PR DESCRIPTION
Pinning test harness dockerfile will fail whenever we update the sdk - so removing the pinned version; also updating to golang 1.23 (current) for module