### PR TITLE
docs: update cursor rules

### DIFF
--- a/.cursor/rules/configTooling.mdc
+++ b/.cursor/rules/configTooling.mdc
@@ -1,0 +1,16 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Configuration and Tooling
+
+- The project root contains configuration files for building, linting, formatting, and testing.
+- Key files include:
+  - [package.json](mdc:package.json): Project dependencies and scripts
+  - [tsconfig.json](mdc:tsconfig.json): TypeScript configuration
+  - [jest.config.ts](mdc:jest.config.ts): Jest test runner configuration
+  - [.eslintrc.json](mdc:.eslintrc.json): ESLint configuration
+  - [.prettierrc](mdc:.prettierrc): Prettier formatting rules
+  - [docker-compose.yml](mdc:docker-compose.yml): Docker Compose setup for multi-service testing
+  - [README.md](mdc:README.md): Project overview and instructions

--- a/.cursor/rules/formatting.mdc
+++ b/.cursor/rules/formatting.mdc
@@ -1,0 +1,10 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Formatting
+
+- All formatting is deferred to Prettier for supported file types (JavaScript, TypeScript, JSON, Markdown, etc.) in the test harness and proxies directories.
+- ESLint is used to enforce code quality and linting rules.
+- No additional formatting rules are enforced by Cursor.

--- a/.cursor/rules/gitCommitConventions.mdc
+++ b/.cursor/rules/gitCommitConventions.mdc
@@ -22,8 +22,8 @@ alwaysApply: true
 - Use of Aviator CLI (`av`) is optional, but recommended for managing stacked branches and pull requests:
   - To create a new stacked branch:
     - `av branch chore-fix-invalid-input`
-  - To synchronize your stack after changes:
-    - `av sync`
+  - To synchronize and git push your stack after changes:
+    - `av sync --push=yes`
   - To create a pull request for your branch:
     - `av pr --title "<title>" --body "<body>"`
 - Prefer Aviator commands for stack management and PR creation to ensure consistency with team workflows, but standard git and GitHub workflows are also supported.

--- a/.cursor/rules/gitCommitConventions.mdc
+++ b/.cursor/rules/gitCommitConventions.mdc
@@ -1,7 +1,7 @@
 ---
 description: 
 globs: 
-alwaysApply: false
+alwaysApply: true
 ---
 # Git Commit Message Conventions
 

--- a/.cursor/rules/gitCommitConventions.mdc
+++ b/.cursor/rules/gitCommitConventions.mdc
@@ -22,6 +22,7 @@ alwaysApply: true
 - Use of Aviator CLI (`av`) is optional, but recommended for managing stacked branches and pull requests:
   - To create a new stacked branch:
     - `av branch chore-fix-invalid-input`
+  - After creating the branch, create commits using `git commit` following the Conventional Commits specification.
   - To synchronize and git push your stack after changes:
     - `av sync --push=yes`
   - To create a pull request for your branch:

--- a/.cursor/rules/gitCommitConventions.mdc
+++ b/.cursor/rules/gitCommitConventions.mdc
@@ -1,0 +1,18 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Git Commit Message Conventions
+
+- All git commit messages in this project must follow the Conventional Commits specification.
+- A commit message should be structured as `<type>(<scope>): <description>`, where:
+  - `type` is one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, or `revert`.
+  - `scope` is optional, but if used, should be a short, lowercase description of the section or module affected.
+  - `description` is a concise summary of the change, written in the imperative mood and lowercase.
+- In this project, scopes are rarely used; most commit messages omit the scope and use the format `<type>: <description>`.
+- Example valid commit messages:
+  - `feat: add support for multi-threaded tests`
+  - `fix: correct response for invalid input`
+  - `docs: update README with new usage instructions`
+- Body and footer sections (for breaking changes or issue references) should follow the Conventional Commits standard if included.

--- a/.cursor/rules/gitCommitConventions.mdc
+++ b/.cursor/rules/gitCommitConventions.mdc
@@ -16,3 +16,15 @@ alwaysApply: false
   - `fix: correct response for invalid input`
   - `docs: update README with new usage instructions`
 - Body and footer sections (for breaking changes or issue references) should follow the Conventional Commits standard if included.
+
+# Aviator CLI Workflow
+
+- Use of Aviator CLI (`av`) is optional, but recommended for managing stacked branches and pull requests:
+  - To create a new stacked branch:
+    - `av branch chore-fix-invalid-input`
+  - To synchronize your stack after changes:
+    - `av sync`
+  - To create a pull request for your branch:
+    - `av pr --title "<title>" --body "<body>"`
+- Prefer Aviator commands for stack management and PR creation to ensure consistency with team workflows, but standard git and GitHub workflows are also supported.
+- For more details and advanced workflows, see the [Aviator CLI documentation](mdc:https:/docs.aviator.co/aviator-cli) and [Aviator CLI Quickstart](mdc:https:/docs.aviator.co/aviator-cli/quickstart).

--- a/.cursor/rules/namingConventions.mdc
+++ b/.cursor/rules/namingConventions.mdc
@@ -1,0 +1,9 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Naming Conventions
+
+- Files and variables in [harness/](mdc:harness) and [proxies/](mdc:proxies) should use camelCase (starting with a lowercase letter).
+- Folders should use kebab-case.

--- a/.cursor/rules/projectStructure.mdc
+++ b/.cursor/rules/projectStructure.mdc
@@ -1,0 +1,26 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Project Structure Guide
+
+- The project root contains configuration files for building, linting, formatting, and testing, such as [package.json](mdc:package.json), [jest.config.ts](mdc:jest.config.ts), and [.eslintrc.json](mdc:.eslintrc.json).
+- The main source code for the test harness is under the [harness/](mdc:harness) directory, which contains:
+  - [features/](mdc:harness/features): Test features and scenarios
+  - [helpers/](mdc:harness/helpers): Shared test utilities and helpers
+  - [mockData/](mdc:harness/mockData): Mock data for tests
+  - [mockServer/](mdc:harness/mockServer): Mock server implementations
+  - [types/](mdc:harness/types): Shared type definitions
+- The [proxies/](mdc:proxies) directory contains language-specific SDK proxies for integration testing, including:
+  - [dotnet/](mdc:proxies/dotnet)
+  - [go/](mdc:proxies/go)
+  - [java/](mdc:proxies/java)
+  - [nodejs/](mdc:proxies/nodejs)
+  - [openfeature-nodejs/](mdc:proxies/openfeature-nodejs)
+  - [php/](mdc:proxies/php)
+  - [python/](mdc:proxies/python)
+  - [ruby/](mdc:proxies/ruby)
+- Each language-specific proxy may contain its own handlers, helpers, and configuration as needed for integration with the test harness.
+- Documentation is found in the [docs/](mdc:docs) directory, with templates in [docs/widdershins/templates/](mdc:docs/widdershins/templates).
+- The main [README.md](mdc:README.md) at the project root provides an overview of the repository and usage instructions.

--- a/.cursor/rules/testingMocks.mdc
+++ b/.cursor/rules/testingMocks.mdc
@@ -1,0 +1,12 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Testing and Mocks
+
+- In this project, test files are almost always placed directly in feature or module directories using the `.test.ts`, `.test.js`, `.spec.ts`, or `.spec.js` suffix.
+- The use of `__tests__/` folders is rare; the suffix-based convention is the primary approach.
+- Test and script files themselves are excluded from this rule.
+- Mock implementations are placed in `__mocks__/` directories within each package or module, such as [harness/mockData/](mdc:harness/mockData) or [harness/mockServer/](mdc:harness/mockServer).
+- This convention is followed in both the main test harness and all SDK proxies.


### PR DESCRIPTION
Update all Cursor rules for project structure, testing, formatting, naming, and commit conventions.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
