### PR TITLE
chore: update git commit conventions rule

### DIFF
--- a/.cursor/rules/gitCommitConventions.mdc
+++ b/.cursor/rules/gitCommitConventions.mdc
@@ -27,5 +27,7 @@ alwaysApply: true
     - `av sync --push=yes`
   - To create a pull request for your branch:
     - `av pr --title "<title>" --body "<body>"`
+    - The PR title should be short and descriptive.
+    - The PR body should use bullet points to summarize the main changes.
 - Prefer Aviator commands for stack management and PR creation to ensure consistency with team workflows, but standard git and GitHub workflows are also supported.
 - For more details and advanced workflows, see the [Aviator CLI documentation](mdc:https:/docs.aviator.co/aviator-cli) and [Aviator CLI Quickstart](mdc:https:/docs.aviator.co/aviator-cli/quickstart).


### PR DESCRIPTION
• updates the git commit conventions documentation in .cursor/rules/gitCommitConventions.mdc

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
