### PR TITLE
chore: Potential fix for code scanning alert no. 53: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -14,6 +14,9 @@ on:
                 type: string
                 description: The title of the PR that triggered this test harness run
 
+permissions:
+    contents: read
+
 jobs:
     run-tests:
         runs-on:


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/test-harness/security/code-scanning/53](https://github.com/DevCycleHQ/test-harness/security/code-scanning/53)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily requires read access to the repository contents. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
