### PR TITLE
chore: Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-dvc-sdk.yml
+++ b/.github/workflows/update-dvc-sdk.yml
@@ -1,4 +1,7 @@
 name: Update DevCycle SDKs to Latest
+permissions:
+    contents: write
+    pull-requests: write
 on:
     schedule:
         - cron: '0 12 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/test-harness/security/code-scanning/49](https://github.com/DevCycleHQ/test-harness/security/code-scanning/49)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required for the workflow. Based on the actions performed in the workflow, the following permissions are necessary:
- `contents: write` for committing and pushing changes to the repository.
- `pull-requests: write` for creating a pull request.

This ensures that the workflow has only the permissions it needs to function correctly, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
