### PR TITLE
feat: Eval Metadata Feature

### DIFF
--- a/harness/helpers/events.ts
+++ b/harness/helpers/events.ts
@@ -88,6 +88,10 @@ export const expectAggregateEvaluationEvent = ({
         metadata.configLastModified = lastModified
         metadata.clientUUID = expect.any(String)
     }
+    if (hasCapability(sdkName, Capabilities.evalReasons)) {
+        // Eval reasoning is specific to each test and is outside the scope of testing in general for these vents.
+        metadata.eval = expect.any(Object)
+    }
 
     let optionalSDKConfigNewUser = []
     let optionalSDKConfigNewEvent = []
@@ -180,6 +184,10 @@ export const expectAggregateDefaultEvent = ({
             metadata.configLastModified = lastModified
         }
         metadata.clientUUID = expect.any(String)
+    }
+    if (hasCapability(sdkName, Capabilities.evalReasons)) {
+        // Eval reasoning is specific to each test and is outside the scope of testing in general for these vents.
+        metadata.eval = expect.any(Object)
     }
 
     let optionalSDKConfigNewUser = []

--- a/harness/helpers/events.ts
+++ b/harness/helpers/events.ts
@@ -89,7 +89,7 @@ export const expectAggregateEvaluationEvent = ({
         metadata.clientUUID = expect.any(String)
     }
     if (hasCapability(sdkName, Capabilities.evalReasons)) {
-        // Eval reasoning is specific to each test and is outside the scope of testing in general for these vents.
+        // Eval reasoning is specific to each test and is outside the scope of testing in general for these events.
         metadata.eval = expect.any(Object)
     }
 

--- a/harness/helpers/events.ts
+++ b/harness/helpers/events.ts
@@ -186,7 +186,7 @@ export const expectAggregateDefaultEvent = ({
         metadata.clientUUID = expect.any(String)
     }
     if (hasCapability(sdkName, Capabilities.evalReasons)) {
-        // Eval reasoning is specific to each test and is outside the scope of testing in general for these vents.
+        // Eval reasoning is specific to each test and is outside the scope of testing in general for these events.
         metadata.eval = expect.any(Object)
     }
 

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -16,6 +16,7 @@ export const Capabilities = {
     v2Config: 'V2Config',
     sdkPlatform: 'SDKPlatform',
     variablesFeatureId: 'VariableFeatureId',
+    evalReasons: 'EvalReasons',
 }
 
 export const SDKPlatformMap = {


### PR DESCRIPTION
Templating this here for more bucketing checks later - but this should fix the failures on the Go SDK atm.
