### PR TITLE
chore: adds default and error eval reason checking on NodeJS Cloud Bucketing SDK

### DIFF
--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -6,6 +6,7 @@ import {
     expectErrorMessageToBe,
     getSDKScope,
     cleanupCurrentClient,
+    hasCapability,
 } from '../helpers'
 import { Capabilities, SDKCapabilities } from '../types'
 
@@ -210,6 +211,11 @@ describe('Variable Tests - Cloud', () => {
         it.each(callVariableMethods)(
             'should return default if mock server returns %s mismatching default value type',
             async (method) => {
+                const hasCloudEvalReason = hasCapability(
+                    sdkName,
+                    Capabilities.cloudEvalReason,
+                )
+
                 scope
                     .post(
                         `/client/${testClient.clientId}/v1/variables/var_key`,
@@ -232,7 +238,6 @@ describe('Variable Tests - Cloud', () => {
                     variablesForTypes['string'].defaultValue,
                 )
                 const variable = await variableResponse.json()
-
                 // We can expect that the object we mocked out earlier is going to be
                 // what is returned to us from the proxy server and verify the entityType
                 // is of type "Variable"
@@ -244,6 +249,14 @@ describe('Variable Tests - Cloud', () => {
                         defaultValue: variablesForTypes['string'].defaultValue,
                         type: variablesForTypes['string'].type,
                         isDefaulted: true,
+                        ...(hasCloudEvalReason
+                            ? {
+                                  eval: {
+                                      reason: 'DEFAULT',
+                                      details: 'Variable Type Mismatch',
+                                  },
+                              }
+                            : {}),
                     },
                 })
             },
@@ -255,6 +268,11 @@ describe('Variable Tests - Cloud', () => {
             it.each(callVariableMethods)(
                 `should return default ${type} %s if mock server returns undefined`,
                 async (method) => {
+                    const hasCloudEvalReason = hasCapability(
+                        sdkName,
+                        Capabilities.cloudEvalReason,
+                    )
+
                     scope
                         .post(
                             `/client/${testClient.clientId}/v1/variables/var_key`,
@@ -281,6 +299,14 @@ describe('Variable Tests - Cloud', () => {
                             defaultValue: variablesForTypes[type].defaultValue,
                             type: variablesForTypes[type].type,
                             isDefaulted: true,
+                            ...(hasCloudEvalReason
+                                ? {
+                                      eval: {
+                                          reason: 'DEFAULT',
+                                          details: 'Error',
+                                      },
+                                  }
+                                : {}),
                         },
                     })
                 },
@@ -325,6 +351,11 @@ describe('Variable Tests - Cloud', () => {
                 `should return defaulted ${type} %s if mock server returns an internal error, \
                 after retrying 5 times`,
                 async (method) => {
+                    const hasCloudEvalReason = hasCapability(
+                        sdkName,
+                        Capabilities.cloudEvalReason,
+                    )
+
                     scope
                         .post(
                             `/client/${testClient.clientId}/v1/variables/var_key`,
@@ -353,6 +384,14 @@ describe('Variable Tests - Cloud', () => {
                             isDefaulted: true,
                             defaultValue: variablesForTypes[type].defaultValue,
                             type: variablesForTypes[type].type,
+                            ...(hasCloudEvalReason
+                                ? {
+                                      eval: {
+                                          reason: 'DEFAULT',
+                                          details: 'Error',
+                                      },
+                                  }
+                                : {}),
                         },
                     })
                 },

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -16,6 +16,8 @@ export const Capabilities = {
     v2Config: 'V2Config',
     sdkPlatform: 'SDKPlatform',
     variablesFeatureId: 'VariableFeatureId',
+    cloudEvalReason: 'CloudEvalReason',
+    evalReason: 'EvalReason',
 }
 
 export const SDKPlatformMap = {
@@ -33,6 +35,7 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.v2Config,
         Capabilities.clientCustomData,
         Capabilities.variablesFeatureId,
+        Capabilities.cloudEvalReason,
     ],
     'OF-NodeJS': [
         Capabilities.edgeDB,


### PR DESCRIPTION
- adds capabilities for Cloud Eval Reason and Eval Reason
- adds Cloud Eval Reason capability to NodeJS Cloud SDK
- update test expectations for NodeJS Cloud Bucketing `variable` tests