### PR TITLE
chore: add eval reason capabilities for nodejs

### DIFF
--- a/harness/features/allVariables.cloud.test.ts
+++ b/harness/features/allVariables.cloud.test.ts
@@ -66,6 +66,7 @@ describe('allVariables Tests - Cloud', () => {
                     200,
                     getMockedVariables(
                         hasCapability(sdkName, Capabilities.variablesFeatureId),
+                        hasCapability(sdkName, Capabilities.evalReason),
                     ),
                 )
             const response = await client.callAllVariables({
@@ -78,6 +79,7 @@ describe('allVariables Tests - Cloud', () => {
             expect(variablesMap).toEqual(
                 getMockedVariables(
                     hasCapability(sdkName, Capabilities.variablesFeatureId),
+                    hasCapability(sdkName, Capabilities.evalReason),
                 ),
             )
         })
@@ -92,6 +94,7 @@ describe('allVariables Tests - Cloud', () => {
                     200,
                     getMockedVariables(
                         hasCapability(sdkName, Capabilities.variablesFeatureId),
+                        hasCapability(sdkName, Capabilities.evalReason),
                     ),
                 )
 
@@ -112,6 +115,7 @@ describe('allVariables Tests - Cloud', () => {
                     200,
                     getMockedVariables(
                         hasCapability(sdkName, Capabilities.variablesFeatureId),
+                        hasCapability(sdkName, Capabilities.evalReason),
                     ),
                 )
 

--- a/harness/features/allVariables.local.test.ts
+++ b/harness/features/allVariables.local.test.ts
@@ -73,6 +73,7 @@ describe('allVariables Tests - Local', () => {
         expect(variablesMap).toEqual(
             getMockedVariables(
                 hasCapability(sdkName, Capabilities.variablesFeatureId),
+                hasCapability(sdkName, Capabilities.evalReason),
             ),
         )
     })

--- a/harness/mockData/variables.ts
+++ b/harness/mockData/variables.ts
@@ -2,6 +2,7 @@ import { BucketedUserConfig, VariableType } from '@devcycle/types'
 
 export function getMockedVariables(
     hasVariablesFeatureId: boolean,
+    hasEvalReason: boolean,
 ): BucketedUserConfig['variables'] {
     return {
         'bool-var': {
@@ -12,6 +13,14 @@ export function getMockedVariables(
             ...(hasVariablesFeatureId
                 ? { _feature: '638680d6fcb67b96878d90e6' }
                 : {}),
+            ...(hasEvalReason
+                ? {
+                      eval: {
+                          details: 'Custom Data -> should-bucket',
+                          reason: 'TARGETING_MATCH',
+                      },
+                  }
+                : {}),
         },
         'string-var': {
             _id: '638681f059f1b81cc9e6c7fb',
@@ -21,6 +30,14 @@ export function getMockedVariables(
             ...(hasVariablesFeatureId
                 ? { _feature: '638680d6fcb67b96878d90e6' }
                 : {}),
+            ...(hasEvalReason
+                ? {
+                      eval: {
+                          details: 'Custom Data -> should-bucket',
+                          reason: 'TARGETING_MATCH',
+                      },
+                  }
+                : {}),
         },
         'number-var': {
             _id: '638681f059f1b81cc9e6c7fc',
@@ -29,6 +46,14 @@ export function getMockedVariables(
             value: 1,
             ...(hasVariablesFeatureId
                 ? { _feature: '638680d6fcb67b96878d90e6' }
+                : {}),
+            ...(hasEvalReason
+                ? {
+                      eval: {
+                          details: 'Custom Data -> should-bucket',
+                          reason: 'TARGETING_MATCH',
+                      },
+                  }
                 : {}),
         },
         'json-var': {
@@ -41,6 +66,14 @@ export function getMockedVariables(
             ...(hasVariablesFeatureId
                 ? { _feature: '638680d6fcb67b96878d90e6' }
                 : {}),
+            ...(hasEvalReason
+                ? {
+                      eval: {
+                          details: 'Custom Data -> should-bucket',
+                          reason: 'TARGETING_MATCH',
+                      },
+                  }
+                : {}),
         },
         'schedule-feature': {
             _id: '6386813a59f1b81cc9e6c68f',
@@ -50,6 +83,14 @@ export function getMockedVariables(
             ...(hasVariablesFeatureId
                 ? { _feature: '6386813a59f1b81cc9e6c68d' }
                 : {}),
+            ...(hasEvalReason
+                ? {
+                      eval: {
+                          details: 'All Users',
+                          reason: 'TARGETING_MATCH',
+                      },
+                  }
+                : {}),
         },
         'unicode-var': {
             _id: '638681f059f1b81cc9e6c7fe',
@@ -58,6 +99,14 @@ export function getMockedVariables(
             value: '↑↑↓↓←→←→BA 🤖',
             ...(hasVariablesFeatureId
                 ? { _feature: '638680d6fcb67b96878d90e6' }
+                : {}),
+            ...(hasEvalReason
+                ? {
+                      eval: {
+                          details: 'Custom Data -> should-bucket',
+                          reason: 'TARGETING_MATCH',
+                      },
+                  }
                 : {}),
         },
     }

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -47,6 +47,7 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.v2Config,
         Capabilities.sdkPlatform,
         Capabilities.variablesFeatureId,
+        Capabilities.evalReason,
     ],
     Python: [
         Capabilities.cloud,

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -36,6 +36,7 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.clientCustomData,
         Capabilities.variablesFeatureId,
         Capabilities.cloudEvalReason,
+        Capabilities.evalReason,
     ],
     'OF-NodeJS': [
         Capabilities.edgeDB,

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -36,7 +36,6 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.clientCustomData,
         Capabilities.variablesFeatureId,
         Capabilities.cloudEvalReason,
-        Capabilities.evalReason,
     ],
     'OF-NodeJS': [
         Capabilities.edgeDB,
@@ -47,7 +46,6 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.v2Config,
         Capabilities.sdkPlatform,
         Capabilities.variablesFeatureId,
-        Capabilities.evalReason,
     ],
     Python: [
         Capabilities.cloud,


### PR DESCRIPTION
add expectations for node and openfeature-node for eval reason to be included in bucketing variable tests.

implemented in https://github.com/DevCycleHQ/js-sdks/pull/1091. This will fail until those changes are merged.