### PR TITLE
chore: add target_id prop in eval object

### DIFF
--- a/harness/mockData/variables.ts
+++ b/harness/mockData/variables.ts
@@ -18,6 +18,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
+                          targetId: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),
@@ -35,6 +36,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
+                          targetId: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),
@@ -52,6 +54,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
+                          targetId: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),
@@ -71,6 +74,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
+                          targetId: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),
@@ -88,6 +92,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'All Users',
                           reason: 'TARGETING_MATCH',
+                          targetId: '6386813a59f1b81cc9e6c6b6',
                       },
                   }
                 : {}),
@@ -105,6 +110,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
+                          targetId: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),

--- a/harness/mockData/variables.ts
+++ b/harness/mockData/variables.ts
@@ -18,7 +18,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
-                          targetId: '638680d659f1b81cc9e6c5ab',
+                          target_id: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),
@@ -36,7 +36,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
-                          targetId: '638680d659f1b81cc9e6c5ab',
+                          target_id: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),
@@ -54,7 +54,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
-                          targetId: '638680d659f1b81cc9e6c5ab',
+                          target_id: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),
@@ -74,7 +74,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
-                          targetId: '638680d659f1b81cc9e6c5ab',
+                          target_id: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),
@@ -92,7 +92,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'All Users',
                           reason: 'TARGETING_MATCH',
-                          targetId: '6386813a59f1b81cc9e6c6b6',
+                          target_id: '6386813a59f1b81cc9e6c6b6',
                       },
                   }
                 : {}),
@@ -110,7 +110,7 @@ export function getMockedVariables(
                       eval: {
                           details: 'Custom Data -> should-bucket',
                           reason: 'TARGETING_MATCH',
-                          targetId: '638680d659f1b81cc9e6c5ab',
+                          target_id: '638680d659f1b81cc9e6c5ab',
                       },
                   }
                 : {}),

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -47,6 +47,7 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.v2Config,
         Capabilities.sdkPlatform,
         Capabilities.variablesFeatureId,
+        Capabilities.evalReason,
     ],
     Python: [
         Capabilities.cloud,

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -36,6 +36,7 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.clientCustomData,
         Capabilities.variablesFeatureId,
         Capabilities.cloudEvalReason,
+        Capabilities.evalReason,
     ],
     'OF-NodeJS': [
         Capabilities.edgeDB,

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -36,7 +36,6 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.clientCustomData,
         Capabilities.variablesFeatureId,
         Capabilities.cloudEvalReason,
-        Capabilities.evalReason,
     ],
     'OF-NodeJS': [
         Capabilities.edgeDB,
@@ -47,7 +46,6 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.v2Config,
         Capabilities.sdkPlatform,
         Capabilities.variablesFeatureId,
-        Capabilities.evalReason,
     ],
     Python: [
         Capabilities.cloud,


### PR DESCRIPTION
including target_id in eval reasons so specific target can be identified