### PR TITLE
chore: exclude of-node from allVariables/allFeatures tests

### DIFF
--- a/harness/features/allFeatures.local.test.ts
+++ b/harness/features/allFeatures.local.test.ts
@@ -10,6 +10,7 @@ import { expectedFeaturesVariationOn } from '../mockData'
 describe('allFeatures Tests - Local', () => {
     const { sdkName, scope } = getSDKScope()
 
+    //TODO: when tests are updated for OF-NodeJS eval capability, remove this allFeatures capability wrapper
     describeCapability(sdkName, Capabilities.allFeatures)(sdkName, () => {
         describe('uninitialized client', () => {
             let testClient: LocalTestClient

--- a/harness/features/allFeatures.local.test.ts
+++ b/harness/features/allFeatures.local.test.ts
@@ -1,4 +1,9 @@
-import { LocalTestClient, getSDKScope, hasCapability, describeCapability } from '../helpers'
+import {
+    LocalTestClient,
+    getSDKScope,
+    hasCapability,
+    describeCapability,
+} from '../helpers'
 import { Capabilities } from '../types'
 import { expectedFeaturesVariationOn } from '../mockData'
 
@@ -6,65 +11,66 @@ describe('allFeatures Tests - Local', () => {
     const { sdkName, scope } = getSDKScope()
 
     describeCapability(sdkName, Capabilities.allFeatures)(sdkName, () => {
+        describe('uninitialized client', () => {
+            let testClient: LocalTestClient
 
-    describe('uninitialized client', () => {
-        let testClient: LocalTestClient
+            beforeEach(async () => {
+                testClient = new LocalTestClient(sdkName)
+                const configRequestUrl = testClient.getValidConfigPath()
+                scope.get(configRequestUrl).times(2).reply(500)
+                await testClient.createClient(true, {
+                    configPollingIntervalMS: 60000,
+                })
+            })
 
-        beforeEach(async () => {
-            testClient = new LocalTestClient(sdkName)
-            const configRequestUrl = testClient.getValidConfigPath()
-            scope.get(configRequestUrl).times(2).reply(500)
-            await testClient.createClient(true, {
-                configPollingIntervalMS: 60000,
+            it('should return empty object if client is uninitialized', async () => {
+                const featuresResponse = await testClient.callAllFeatures({
+                    user_id: 'user1',
+                    customData: { 'should-bucket': true },
+                })
+                const features = await featuresResponse.json()
+                expect(features).toMatchObject({})
             })
         })
 
-        it('should return empty object if client is uninitialized', async () => {
-            const featuresResponse = await testClient.callAllFeatures({
-                user_id: 'user1',
-                customData: { 'should-bucket': true },
+        describe('initialized client', () => {
+            let testClient: LocalTestClient
+
+            beforeEach(async () => {
+                testClient = new LocalTestClient(sdkName, scope)
+                if (hasCapability(sdkName, Capabilities.sdkConfigEvent)) {
+                    scope
+                        .post(`/client/${testClient.clientId}/v1/events/batch`)
+                        .reply(201, {
+                            message: 'Successfully received events.',
+                        })
+                }
+
+                await testClient.createClient(true, {
+                    configPollingIntervalMS: 60000,
+                })
             })
-            const features = await featuresResponse.json()
-            expect(features).toMatchObject({})
+
+            it('should return all features for user without custom data', async () => {
+                const featuresResponse = await testClient.callAllFeatures({
+                    user_id: 'user3',
+                })
+                const features = (await featuresResponse.json()).data
+                expect(features).toMatchObject({
+                    'schedule-feature': {
+                        ...expectedFeaturesVariationOn['schedule-feature'],
+                    },
+                })
+            })
+
+            it('should return all features for user with custom data', async () => {
+                const featuresResponse = await testClient.callAllFeatures({
+                    user_id: 'user1',
+                    customData: { 'should-bucket': true },
+                })
+                const features = (await featuresResponse.json()).data
+                expect(features).toMatchObject(expectedFeaturesVariationOn)
+            })
         })
-    })
-
-    describe('initialized client', () => {
-        let testClient: LocalTestClient
-
-        beforeEach(async () => {
-            testClient = new LocalTestClient(sdkName, scope)
-            if (hasCapability(sdkName, Capabilities.sdkConfigEvent)) {
-                scope
-                    .post(`/client/${testClient.clientId}/v1/events/batch`)
-                    .reply(201, { message: 'Successfully received events.' })
-            }
-
-            await testClient.createClient(true, {
-                configPollingIntervalMS: 60000,
-            })
-        })
-
-        it('should return all features for user without custom data', async () => {
-            const featuresResponse = await testClient.callAllFeatures({
-                user_id: 'user3',
-            })
-            const features = (await featuresResponse.json()).data
-            expect(features).toMatchObject({
-                'schedule-feature': {
-                    ...expectedFeaturesVariationOn['schedule-feature'],
-                },
-            })
-        })
-
-        it('should return all features for user with custom data', async () => {
-            const featuresResponse = await testClient.callAllFeatures({
-                user_id: 'user1',
-                customData: { 'should-bucket': true },
-            })
-            const features = (await featuresResponse.json()).data
-            expect(features).toMatchObject(expectedFeaturesVariationOn)
-        })
-    })
     })
 })

--- a/harness/features/allFeatures.local.test.ts
+++ b/harness/features/allFeatures.local.test.ts
@@ -1,9 +1,11 @@
-import { LocalTestClient, getSDKScope, hasCapability } from '../helpers'
+import { LocalTestClient, getSDKScope, hasCapability, describeCapability } from '../helpers'
 import { Capabilities } from '../types'
 import { expectedFeaturesVariationOn } from '../mockData'
 
 describe('allFeatures Tests - Local', () => {
     const { sdkName, scope } = getSDKScope()
+
+    describeCapability(sdkName, Capabilities.allFeatures)(sdkName, () => {
 
     describe('uninitialized client', () => {
         let testClient: LocalTestClient
@@ -63,5 +65,6 @@ describe('allFeatures Tests - Local', () => {
             const features = (await featuresResponse.json()).data
             expect(features).toMatchObject(expectedFeaturesVariationOn)
         })
+    })
     })
 })

--- a/harness/features/allVariables.local.test.ts
+++ b/harness/features/allVariables.local.test.ts
@@ -12,73 +12,72 @@ describe('allVariables Tests - Local', () => {
     const { sdkName, scope } = getSDKScope()
 
     describeCapability(sdkName, Capabilities.allVariables)(sdkName, () => {
+        it('should return an empty object if client is not initialized', async () => {
+            const delayClient = new LocalTestClient(sdkName)
 
-    it('should return an empty object if client is not initialized', async () => {
-        const delayClient = new LocalTestClient(sdkName)
+            let interceptor = scope
+                .get(delayClient.getValidConfigPath())
+                .delay(2000)
+            interceptor.reply(200, delayClient.getValidConfig())
 
-        let interceptor = scope
-            .get(delayClient.getValidConfigPath())
-            .delay(2000)
-        interceptor.reply(200, delayClient.getValidConfig())
+            if (hasCapability(sdkName, Capabilities.sdkConfigEvent)) {
+                interceptor = scope.post(
+                    `/client/${delayClient.clientId}/v1/events/batch`,
+                )
+                interceptor.reply(201, {
+                    message: 'Successfully received events.',
+                })
+            }
 
-        if (hasCapability(sdkName, Capabilities.sdkConfigEvent)) {
-            interceptor = scope.post(
-                `/client/${delayClient.clientId}/v1/events/batch`,
-            )
-            interceptor.reply(201, {
-                message: 'Successfully received events.',
+            await delayClient.createClient(false, {
+                eventFlushIntervalMS: 500,
+                logLevel: 'debug',
             })
-        }
 
-        await delayClient.createClient(false, {
-            eventFlushIntervalMS: 500,
-            logLevel: 'debug',
+            const response = await delayClient.callAllVariables({
+                user_id: 'test_user',
+                email: 'user@gmail.com',
+                customData: { 'should-bucket': true },
+            })
+            const { data: variablesMap } = await response.json()
+
+            expect(variablesMap).toMatchObject({})
+            await waitForRequest(
+                scope,
+                interceptor,
+                3000,
+                'Config request never received!',
+            )
         })
 
-        const response = await delayClient.callAllVariables({
-            user_id: 'test_user',
-            email: 'user@gmail.com',
-            customData: { 'should-bucket': true },
+        it('should return a variable map for a bucketed user', async () => {
+            const client = new LocalTestClient(sdkName, scope)
+
+            if (hasCapability(sdkName, Capabilities.sdkConfigEvent)) {
+                scope
+                    .post(`/client/${client.clientId}/v1/events/batch`)
+                    .reply(201, { message: 'Successfully received events.' })
+            }
+
+            await client.createClient(true, {
+                configPollingIntervalMS: 60000,
+                eventFlushIntervalMS: 500,
+            })
+
+            const response = await client.callAllVariables({
+                user_id: 'test_user',
+                email: 'user@gmail.com',
+                customData: { 'should-bucket': true },
+            })
+            const { data: variablesMap, entityType } = await response.json()
+
+            expect(entityType).toEqual('Object')
+            expect(variablesMap).toEqual(
+                getMockedVariables(
+                    hasCapability(sdkName, Capabilities.variablesFeatureId),
+                    hasCapability(sdkName, Capabilities.evalReason),
+                ),
+            )
         })
-        const { data: variablesMap } = await response.json()
-
-        expect(variablesMap).toMatchObject({})
-        await waitForRequest(
-            scope,
-            interceptor,
-            3000,
-            'Config request never received!',
-        )
-    })
-
-    it('should return a variable map for a bucketed user', async () => {
-        const client = new LocalTestClient(sdkName, scope)
-
-        if (hasCapability(sdkName, Capabilities.sdkConfigEvent)) {
-            scope
-                .post(`/client/${client.clientId}/v1/events/batch`)
-                .reply(201, { message: 'Successfully received events.' })
-        }
-
-        await client.createClient(true, {
-            configPollingIntervalMS: 60000,
-            eventFlushIntervalMS: 500,
-        })
-
-        const response = await client.callAllVariables({
-            user_id: 'test_user',
-            email: 'user@gmail.com',
-            customData: { 'should-bucket': true },
-        })
-        const { data: variablesMap, entityType } = await response.json()
-
-        expect(entityType).toEqual('Object')
-        expect(variablesMap).toEqual(
-            getMockedVariables(
-                hasCapability(sdkName, Capabilities.variablesFeatureId),
-                hasCapability(sdkName, Capabilities.evalReason),
-            ),
-        )
-    })
     })
 })

--- a/harness/features/allVariables.local.test.ts
+++ b/harness/features/allVariables.local.test.ts
@@ -76,7 +76,9 @@ describe('allVariables Tests - Local', () => {
             expect(variablesMap).toEqual(
                 getMockedVariables(
                     hasCapability(sdkName, Capabilities.variablesFeatureId),
-                    hasCapability(sdkName, Capabilities.evalReason),
+                    hasCapability(sdkName, Capabilities.evalReason) ||
+                        // TODO: this is just to get tests to pass since docker container now has latest wasm code returning eval reasons
+                        hasCapability(sdkName, Capabilities.tempEvalReason),
                 ),
             )
         })

--- a/harness/features/allVariables.local.test.ts
+++ b/harness/features/allVariables.local.test.ts
@@ -3,12 +3,15 @@ import {
     waitForRequest,
     getSDKScope,
     hasCapability,
+    describeCapability,
 } from '../helpers'
 import { Capabilities } from '../types'
 import { getMockedVariables } from '../mockData'
 
 describe('allVariables Tests - Local', () => {
     const { sdkName, scope } = getSDKScope()
+
+    describeCapability(sdkName, Capabilities.allVariables)(sdkName, () => {
 
     it('should return an empty object if client is not initialized', async () => {
         const delayClient = new LocalTestClient(sdkName)
@@ -76,5 +79,6 @@ describe('allVariables Tests - Local', () => {
                 hasCapability(sdkName, Capabilities.evalReason),
             ),
         )
+    })
     })
 })

--- a/harness/features/allVariables.local.test.ts
+++ b/harness/features/allVariables.local.test.ts
@@ -11,6 +11,7 @@ import { getMockedVariables } from '../mockData'
 describe('allVariables Tests - Local', () => {
     const { sdkName, scope } = getSDKScope()
 
+    //TODO: when tests are updated for OF-NodeJS eval capability, remove this allVariables capability wrapper
     describeCapability(sdkName, Capabilities.allVariables)(sdkName, () => {
         it('should return an empty object if client is not initialized', async () => {
             const delayClient = new LocalTestClient(sdkName)

--- a/harness/types/capabilities.test.ts
+++ b/harness/types/capabilities.test.ts
@@ -55,6 +55,8 @@ describe('SDKCapabilities Unit Tests', () => {
                 'SDKConfigEvent',
                 'ClientUUID',
                 'V2Config',
+                'AllVariables',
+                'AllFeatures',
             ],
         })
     })
@@ -77,6 +79,8 @@ describe('SDKCapabilities Unit Tests', () => {
             'SDKConfigEvent',
             'ClientUUID',
             'V2Config',
+            'AllVariables',
+            'AllFeatures',
         ])
     })
 })

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -26,6 +26,7 @@ export const SDKPlatformMap = {
     'OF-NodeJS': 'nodejs-of',
 }
 
+//TODO: when tests are updated for OF-NodeJS eval capability, remove concept of allVariables/allFeatures as a capability
 let sdkCapabilities: { [key: string]: string[] } = {
     NodeJS: [
         Capabilities.edgeDB,

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -18,6 +18,8 @@ export const Capabilities = {
     variablesFeatureId: 'VariableFeatureId',
     cloudEvalReason: 'CloudEvalReason',
     evalReason: 'EvalReason',
+    allVariables: 'AllVariables',
+    allFeatures: 'AllFeatures',
 }
 
 export const SDKPlatformMap = {
@@ -36,6 +38,8 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.clientCustomData,
         Capabilities.variablesFeatureId,
         Capabilities.cloudEvalReason,
+        Capabilities.allVariables,
+        Capabilities.allFeatures,
     ],
     'OF-NodeJS': [
         Capabilities.edgeDB,
@@ -52,12 +56,16 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.edgeDB,
         Capabilities.clientCustomData,
         Capabilities.v2Config,
+        Capabilities.allVariables,
+        Capabilities.allFeatures,
     ],
     DotNet: [
         Capabilities.cloud,
         Capabilities.edgeDB,
         Capabilities.clientCustomData,
         Capabilities.v2Config,
+        Capabilities.allVariables,
+        Capabilities.allFeatures,
         //Capabilities.sdkConfigEvent,
         //Capabilities.clientUUID,
     ],
@@ -66,6 +74,8 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.edgeDB,
         Capabilities.clientCustomData,
         Capabilities.v2Config,
+        Capabilities.allVariables,
+        Capabilities.allFeatures,
     ],
     Go: [
         Capabilities.cloud,
@@ -78,13 +88,21 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.sdkConfigEvent,
         Capabilities.clientUUID,
         Capabilities.v2Config,
+        Capabilities.allVariables,
+        Capabilities.allFeatures,
     ],
     Ruby: [
         Capabilities.clientCustomData,
         Capabilities.v2Config,
         Capabilities.variablesFeatureId,
+        Capabilities.allVariables,
+        Capabilities.allFeatures,
     ],
-    PHP: [Capabilities.cloudProxy],
+    PHP: [
+        Capabilities.cloudProxy,
+        Capabilities.allVariables,
+        Capabilities.allFeatures,
+    ],
 }
 
 export const getCapabilities = () => {

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -20,6 +20,7 @@ export const Capabilities = {
     evalReason: 'EvalReason',
     allVariables: 'AllVariables',
     allFeatures: 'AllFeatures',
+    tempEvalReason: 'tempEvalReason',
 }
 
 export const SDKPlatformMap = {
@@ -41,6 +42,8 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.cloudEvalReason,
         Capabilities.allVariables,
         Capabilities.allFeatures,
+        //TODO: remove this when node released and use evalReason
+        Capabilities.tempEvalReason,
     ],
     'OF-NodeJS': [
         Capabilities.edgeDB,


### PR DESCRIPTION
adding allVariables and allFeatures capabilities so of-node tests can skip these test files
- these functions are not supported by OF and the proxy was just calling devcycle sdk functions, which conflicted with capability for evalReason and caused tests to fail
- lets test-harness pass for of-node, in future it will have its own evalReasons capability for variable call only and i can undo this change