### PR TITLE
chore: add tests for openfeature eval metadata

### DIFF
--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -60,10 +60,14 @@ describe('Variable Tests - Cloud', () => {
         return sdkName === 'OF-NodeJS'
             ? {
                   reason,
-                  flagMetadata: {
-                      evalReasonDetails: details || '',
-                      evalReasonTargetId: target_id || '',
-                  },
+                  ...(hasCapability(sdkName, Capabilities.flagMetadata)
+                      ? {
+                            flagMetadata: {
+                                evalReasonDetails: details || '',
+                                evalReasonTargetId: target_id || '',
+                            },
+                        }
+                      : {}),
               }
             : { eval: { reason, details, target_id } }
     }

--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -60,14 +60,15 @@ describe('Variable Tests - Cloud', () => {
         return sdkName === 'OF-NodeJS'
             ? {
                   reason,
-                  ...(hasCapability(sdkName, Capabilities.flagMetadata)
+                  flagMetadata: hasCapability(
+                      sdkName,
+                      Capabilities.flagMetadata,
+                  )
                       ? {
-                            flagMetadata: {
-                                evalReasonDetails: details || '',
-                                evalReasonTargetId: target_id || '',
-                            },
+                            evalReasonDetails: details || '',
+                            evalReasonTargetId: target_id || '',
                         }
-                      : {}),
+                      : {},
               }
             : { eval: { reason, details, target_id } }
     }

--- a/harness/features/variable.cloud.test.ts
+++ b/harness/features/variable.cloud.test.ts
@@ -58,7 +58,13 @@ describe('Variable Tests - Cloud', () => {
         target_id?: string,
     ) {
         return sdkName === 'OF-NodeJS'
-            ? { reason }
+            ? {
+                  reason,
+                  flagMetadata: {
+                      evalReasonDetails: details || '',
+                      evalReasonTargetId: target_id || '',
+                  },
+              }
             : { eval: { reason, details, target_id } }
     }
 
@@ -356,7 +362,10 @@ describe('Variable Tests - Cloud', () => {
                             isDefaulted: false,
                             type: variablesForTypes[type].type,
                             ...(hasCloudEvalReason && sdkName === 'OF-NodeJS'
-                                ? { reason: EVAL_REASONS.TARGETING_MATCH }
+                                ? {
+                                      reason: EVAL_REASONS.TARGETING_MATCH,
+                                      flagMetadata: {},
+                                  }
                                 : {}),
                         },
                     })

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -639,14 +639,15 @@ describe('Variable Tests - Local', () => {
         return sdkName === 'OF-NodeJS'
             ? {
                   reason,
-                  ...(hasCapability(sdkName, Capabilities.flagMetadata)
+                  flagMetadata: hasCapability(
+                      sdkName,
+                      Capabilities.flagMetadata,
+                  )
                       ? {
-                            flagMetadata: {
-                                evalReasonDetails: details || '',
-                                evalReasonTargetId: target_id || '',
-                            },
+                            evalReasonDetails: details || '',
+                            evalReasonTargetId: target_id || '',
                         }
-                      : {}),
+                      : {},
               }
             : { eval: { reason, details, target_id } }
     }

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -637,7 +637,13 @@ describe('Variable Tests - Local', () => {
         target_id?: string,
     ) {
         return sdkName === 'OF-NodeJS'
-            ? { reason }
+            ? {
+                  reason,
+                  flagMetadata: {
+                      evalReasonDetails: details || '',
+                      evalReasonTargetId: target_id || '',
+                  },
+              }
             : { eval: { reason, details, target_id } }
     }
 })

--- a/harness/features/variable.local.test.ts
+++ b/harness/features/variable.local.test.ts
@@ -639,10 +639,14 @@ describe('Variable Tests - Local', () => {
         return sdkName === 'OF-NodeJS'
             ? {
                   reason,
-                  flagMetadata: {
-                      evalReasonDetails: details || '',
-                      evalReasonTargetId: target_id || '',
-                  },
+                  ...(hasCapability(sdkName, Capabilities.flagMetadata)
+                      ? {
+                            flagMetadata: {
+                                evalReasonDetails: details || '',
+                                evalReasonTargetId: target_id || '',
+                            },
+                        }
+                      : {}),
               }
             : { eval: { reason, details, target_id } }
     }

--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -21,6 +21,7 @@ export const Capabilities = {
     allVariables: 'AllVariables',
     allFeatures: 'AllFeatures',
     tempEvalReason: 'tempEvalReason',
+    flagMetadata: 'flagMetadata',
 }
 
 export const SDKPlatformMap = {

--- a/proxies/openfeature-nodejs/handlers/location.ts
+++ b/proxies/openfeature-nodejs/handlers/location.ts
@@ -241,6 +241,7 @@ class DVCVariable implements DVCVariableInterface<any> {
         public isDefaulted: DVCVariableInterface<any>['isDefaulted'],
         public type: DVCVariableInterface<any>['type'],
         public reason?: string,
+        public flagMetadata?: Record<string, string | number | boolean>,
     ) {}
 }
 
@@ -275,6 +276,7 @@ const dvcVariableFromEvaluationDetails = <T extends FlagValue>(
         (varType.charAt(0).toUpperCase() +
             varType.slice(1)) as DVCVariable['type'],
         evalDetails.reason,
+        evalDetails.flagMetadata,
     )
     console.log(`dvcVar: ${JSON.stringify(dvcVar)}`)
     return dvcVar


### PR DESCRIPTION
extra fields for eval reasons "details" and "target_id" can be returned from OF via the flagMetadata. 

Update proxy to return this and add expectations to the tests.