### PR TITLE
fix: update aggVariableEvaluated event metadata format

### DIFF
--- a/harness/helpers/events.ts
+++ b/harness/helpers/events.ts
@@ -109,7 +109,9 @@ export const expectAggregateEvaluationEvent = ({
     }
 
     if (hasCapability(sdkName, Capabilities.eventsEvalReason)) {
-        metadata.eval = expect.objectContaining<Record<string, number>>
+        metadata.eval = expect.objectContaining({
+            TARGETING_MATCH: expect.any(Number),
+        })
     }
 
     expect(body).toEqual({


### PR DESCRIPTION
- fix: `aggVariableEvaluated` events metadata should contain eval with a `TARGETING_MATCH` reason with a number value