### PR TITLE
Update ruby proxy to enable cloud bucketing

### DIFF
--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -101,6 +101,7 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.allFeatures,
     ],
     Ruby: [
+        Capabilities.cloud,
         Capabilities.clientCustomData,
         Capabilities.v2Config,
         Capabilities.variablesFeatureId,

--- a/proxies/ruby/helpers.rb
+++ b/proxies/ruby/helpers.rb
@@ -60,7 +60,7 @@ end
 def get_entity_type_from_class_name(class_name)
   entity_type = class_name == 'NilClass' ? 'Void' : class_name.split('::').last
   case entity_type
-  when 'DVCClient'
+  when 'DVCClient', 'DVCCloudClient'
     return 'Client'
   when 'Hash'
     return 'Object'


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add support for `enableCloudBucketing` to the Ruby proxy to align with other proxies and `Capabilities.cloud`.

---

[Open in Web](https://cursor.com/agents?id=bc-1992c615-7294-4b0d-95be-b093493aab18) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1992c615-7294-4b0d-95be-b093493aab18) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)