### PR TITLE
chore: update python capabilities for eval reasons

### DIFF
--- a/harness/types/capabilities.ts
+++ b/harness/types/capabilities.ts
@@ -61,6 +61,9 @@ let sdkCapabilities: { [key: string]: string[] } = {
         Capabilities.edgeDB,
         Capabilities.clientCustomData,
         Capabilities.v2Config,
+        Capabilities.cloudEvalReason,
+        Capabilities.evalReason,
+        Capabilities.eventsEvalReason,
     ],
     DotNet: [
         Capabilities.cloud,


### PR DESCRIPTION
python released with eval reason - add capabilities to be run by default