### PR TITLE
fix: pin MEL.Abstractions and System.Text.Json to 10.0.0 in dotnet proxy

### DIFF
--- a/proxies/dotnet/dotnet.csproj
+++ b/proxies/dotnet/dotnet.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="DevCycle.SDK.Server.Local" Version="4.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The DevCycle .NET SDK now requires `Microsoft.Extensions.Logging.Abstractions >= 10.0.0` (via OpenFeature 2.13.0) and `System.Text.Json >= 10.0.0`. Both packages ship `net8.0` TFMs so the proxy can stay on `net8.0` and the Docker base image stays on `dotnet/sdk:8.0`.

Without explicit pins here, NuGet raises `NU1605` during restore because the .NET 8 framework's implicit MEL reference conflicts with the transitive >= 10.0.0 requirement coming from the SDK.

### Related

DevCycleHQ/dotnet-server-sdk#203